### PR TITLE
Not overwriting project

### DIFF
--- a/ViAn/GUI/projectdialog.cpp
+++ b/ViAn/GUI/projectdialog.cpp
@@ -66,16 +66,26 @@ void ProjectDialog::ok_btn_clicked() {
         QMessageBox msg_box;
         msg_box.setModal(true);
         msg_box.setText("This folder already exist. Are you sure you wan't to continue?");
-        msg_box.setInformativeText("This will overrite the current project.");
-        msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        msg_box.setInformativeText("Yes will overrite and Open will open the current project.");
+        msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Open);
         msg_box.setDefaultButton(QMessageBox::No);
         int reply = msg_box.exec();
+        if (reply == QMessageBox::Open) {
+            qDebug() << path_text->text();
+            if (path_text->text() == "") {
+                qDebug() << "is empty";
+                m_dir = "C:" + m_dir;
+            }
+            emit open_project(m_dir + name_text->text());
+            qDebug() << m_dir;
+            qDebug() << "open project";
+            close();
+            return;
+        }
         if (reply != QMessageBox::Yes) return;
     }
-
     emit project_path(name_text->text(), path_text->text());
     close();
-
 }
 
 void ProjectDialog::cancel_btn_clicked() {

--- a/ViAn/GUI/projectdialog.cpp
+++ b/ViAn/GUI/projectdialog.cpp
@@ -60,25 +60,22 @@ void ProjectDialog::browse_btn_clicked() {
 
 void ProjectDialog::ok_btn_clicked() {
     QString m_dir = path_text->text() + "/" + name_text->text() + "/";
+    if (path_text->text() == "") {
+        m_dir = "C:" + m_dir;
+    }
     QDir pathDir(m_dir);
     if (pathDir.exists()) {
         // Create confirmation dialog since the path already exists
         QMessageBox msg_box;
         msg_box.setModal(true);
-        msg_box.setText("This folder already exist. Are you sure you wan't to continue?");
-        msg_box.setInformativeText("Yes will overrite and Open will open the current project.");
+        msg_box.setText("This project already exist. Are you sure you want to continue?");
+        msg_box.setInformativeText("Open will open the existing project.");
         msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Open);
         msg_box.setDefaultButton(QMessageBox::No);
         int reply = msg_box.exec();
         // Open the already existing project
         if (reply == QMessageBox::Open) {
-            qDebug() << path_text->text();
-            if (path_text->text() == "") {
-                m_dir = "C:" + m_dir;
-            }
             emit open_project(m_dir + name_text->text());
-            qDebug() << m_dir;
-            qDebug() << "open project";
             close();
             return;
         }

--- a/ViAn/GUI/projectdialog.cpp
+++ b/ViAn/GUI/projectdialog.cpp
@@ -4,6 +4,7 @@
 #include <QBoxLayout>
 #include <QFormLayout>
 #include <QFileDialog>
+#include <QMessageBox>
 
 #include <QDebug>
 
@@ -14,8 +15,9 @@
  */
 ProjectDialog::ProjectDialog(QWidget *parent) : QDialog(parent) {
     setWindowTitle("New project");
+    setModal(true);
     // remove question mark from the title bar
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::WindowStaysOnTopHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     QVBoxLayout* vertical_layout = new QVBoxLayout;
     path_text = new QLineEdit(this);
     name_text = new QLineEdit(this);
@@ -57,6 +59,20 @@ void ProjectDialog::browse_btn_clicked() {
 }
 
 void ProjectDialog::ok_btn_clicked() {
+    QString m_dir = path_text->text() + "/" + name_text->text() + "/";
+    QDir pathDir(m_dir);
+    if (pathDir.exists()) {
+        qDebug() << "path exists";
+        QMessageBox msg_box;
+        msg_box.setModal(true);
+        msg_box.setText("This folder already exist. Are you sure you wan't to continue?");
+        msg_box.setInformativeText("This will overrite the current project.");
+        msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        msg_box.setDefaultButton(QMessageBox::No);
+        int reply = msg_box.exec();
+        if (reply != QMessageBox::Yes) return;
+    }
+
     emit project_path(name_text->text(), path_text->text());
     close();
 

--- a/ViAn/GUI/projectdialog.cpp
+++ b/ViAn/GUI/projectdialog.cpp
@@ -62,7 +62,7 @@ void ProjectDialog::ok_btn_clicked() {
     QString m_dir = path_text->text() + "/" + name_text->text() + "/";
     QDir pathDir(m_dir);
     if (pathDir.exists()) {
-        qDebug() << "path exists";
+        // Create confirmation dialog since the path already exists
         QMessageBox msg_box;
         msg_box.setModal(true);
         msg_box.setText("This folder already exist. Are you sure you wan't to continue?");
@@ -70,10 +70,10 @@ void ProjectDialog::ok_btn_clicked() {
         msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Open);
         msg_box.setDefaultButton(QMessageBox::No);
         int reply = msg_box.exec();
+        // Open the already existing project
         if (reply == QMessageBox::Open) {
             qDebug() << path_text->text();
             if (path_text->text() == "") {
-                qDebug() << "is empty";
                 m_dir = "C:" + m_dir;
             }
             emit open_project(m_dir + name_text->text());

--- a/ViAn/GUI/projectdialog.h
+++ b/ViAn/GUI/projectdialog.h
@@ -18,7 +18,7 @@ public:
 
 signals:
     void project_path(QString name, QString path);
-    void open_project(QString path);
+    void open_project(QString proj_path);
 
 public slots:
 

--- a/ViAn/GUI/projectdialog.h
+++ b/ViAn/GUI/projectdialog.h
@@ -18,6 +18,7 @@ public:
 
 signals:
     void project_path(QString name, QString path);
+    void open_project(QString path);
 
 public slots:
 

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -59,7 +59,7 @@ void ProjectWidget::add_project(QString project_name, QString project_path) {
     std::string _tmp_name = project_name.toStdString();
     std::string _tmp_path = project_path.toStdString();
     parentWidget()->parentWidget()->setWindowTitle(project_name);
-    m_proj = new Project(_tmp_name, _tmp_path); 
+    m_proj = new Project(_tmp_name, _tmp_path);
     m_proj->save_project();
     _tmp_path.append(_tmp_name);
     emit proj_path(m_proj->getDir());

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -592,7 +592,6 @@ void ProjectWidget::save_project() {
  * Slot function to open a previously created project
  */
 void ProjectWidget::open_project(QString project_path) {
-    qDebug() << project_path;
     if (project_path.isEmpty()) return;
     if (m_proj != nullptr) close_project();
     set_status_bar("Opening project");

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -45,6 +45,7 @@ ProjectWidget::ProjectWidget(QWidget *parent) : QTreeWidget(parent) {
 void ProjectWidget::new_project() {
     ProjectDialog* proj_dialog = new ProjectDialog();
     QObject::connect(proj_dialog, SIGNAL(project_path(QString, QString)), this, SLOT(add_project(QString, QString)));
+    QObject::connect(proj_dialog, SIGNAL(open_project(QString)), this, SLOT(open_project(QString)));
 }
 
 /**
@@ -591,6 +592,7 @@ void ProjectWidget::save_project() {
  * Slot function to open a previously created project
  */
 void ProjectWidget::open_project(QString project_path) {
+    qDebug() << project_path;
     if (project_path.isEmpty()) return;
     if (m_proj != nullptr) close_project();
     set_status_bar("Opening project");


### PR DESCRIPTION
When creating a new project, before the prompt accepts the answer, it checks if the path already exists. If it does, it alerts the user and asks if he/she wanna continue and overwrite the old one, open the old one or just cancel the action.