### PR TITLE
Remove project

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -62,7 +62,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, SIGNAL(load_bookmarks(VideoProject*)), bookmark_wgt, SLOT(load_bookmarks(VideoProject*)));
     connect(bookmark_wgt, SIGNAL(play_bookmark_video(VideoProject*,int)), video_wgt, SLOT(load_marked_video(VideoProject*)));
     connect(project_wgt, &ProjectWidget::project_closed, bookmark_wgt, &BookmarkWidget::clear_bookmarks);
-    bookmark_dock->setWidget(bookmark_wgt);    
+    bookmark_dock->setWidget(bookmark_wgt);
 
     //Initialize menu bar
     init_file_menu();
@@ -112,6 +112,13 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::marked_video, video_wgt, &VideoWidget::clear_tag);
     connect(project_wgt, &ProjectWidget::marked_video, video_wgt->frame_wgt, &FrameWidget::set_video_project);
 
+
+
+    connect(project_wgt, &ProjectWidget::project_closed, video_wgt, &VideoWidget::clear_current_video);
+    connect(project_wgt, SIGNAL(item_removed(VideoProject*)), video_wgt, SLOT(remove_item(VideoProject*)));
+
+
+
     connect(analysis_wgt, SIGNAL(name_in_tree(QTreeWidgetItem*,QString)), project_wgt, SLOT(set_tree_item_name(QTreeWidgetItem*,QString)));
 
     connect(project_wgt, SIGNAL(marked_analysis(AnalysisProxy*)), video_wgt->frame_wgt, SLOT(set_analysis(AnalysisProxy*)));
@@ -134,6 +141,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::update_frame, video_wgt->playback_slider, &AnalysisSlider::update);
     connect(project_wgt, &ProjectWidget::update_frame, video_wgt->frame_wgt, &FrameWidget::update);
     connect(this, &MainWindow::open_project, project_wgt, &ProjectWidget::open_project);
+
 
     // Recent projects menu
     RecentProjectDialog* rp_dialog = new RecentProjectDialog(this);

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -112,12 +112,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::marked_video, video_wgt, &VideoWidget::clear_tag);
     connect(project_wgt, &ProjectWidget::marked_video, video_wgt->frame_wgt, &FrameWidget::set_video_project);
 
-
-
     connect(project_wgt, &ProjectWidget::project_closed, video_wgt, &VideoWidget::clear_current_video);
     connect(project_wgt, SIGNAL(item_removed(VideoProject*)), video_wgt, SLOT(remove_item(VideoProject*)));
-
-
 
     connect(analysis_wgt, SIGNAL(name_in_tree(QTreeWidgetItem*,QString)), project_wgt, SLOT(set_tree_item_name(QTreeWidgetItem*,QString)));
 
@@ -141,7 +137,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::update_frame, video_wgt->playback_slider, &AnalysisSlider::update);
     connect(project_wgt, &ProjectWidget::update_frame, video_wgt->frame_wgt, &FrameWidget::update);
     connect(this, &MainWindow::open_project, project_wgt, &ProjectWidget::open_project);
-
 
     // Recent projects menu
     RecentProjectDialog* rp_dialog = new RecentProjectDialog(this);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -58,7 +58,7 @@ void ProjectWidget::add_project(QString project_name, QString project_path) {
     close_project();
     std::string _tmp_name = project_name.toStdString();
     std::string _tmp_path = project_path.toStdString();
-    parentWidget()->parentWidget()->setWindowTitle(project_name);
+    set_main_window_name(project_name);
     m_proj = new Project(_tmp_name, _tmp_path); 
     m_proj->save_project();
     _tmp_path.append(_tmp_name);
@@ -524,7 +524,6 @@ void ProjectWidget::remove_item() {
     delete_box.setDefaultButton(QMessageBox::No);
     if (delete_box.exec() == QMessageBox::Yes) {
         for (auto item : selectedItems()) {
-            qDebug() << "in for, selected items";
             if (item->type() == FOLDER_ITEM) {
                 std::vector<VideoItem*> v_items;
                 get_video_items(item, v_items);
@@ -534,13 +533,13 @@ void ProjectWidget::remove_item() {
             }
 
             else if (item->type() == VIDEO_ITEM) {
-                qDebug() << "is video";
                 VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
                 emit item_removed(vid_item->get_video_project());
             }
-            else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
-                qDebug() << "in tag or analysis";
-            }
+            // TODO Fix these cases
+//            else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
+//
+//            }
             delete item;
         }
     }
@@ -617,7 +616,7 @@ void ProjectWidget::open_project(QString project_path) {
     tree_state.set_tree(invisibleRootItem());
     tree_state.load_state(m_proj->getDir() + "treestate");
 
-    parentWidget()->parentWidget()->setWindowTitle(QString::fromStdString(m_proj->getName()));
+    set_main_window_name(QString::fromStdString(m_proj->getName()));
     emit proj_path(m_proj->getDir());
     for (auto vid_proj : m_proj->get_videos()) {
         insert_to_path_index(vid_proj);
@@ -632,7 +631,7 @@ void ProjectWidget::open_project(QString project_path) {
 void ProjectWidget::close_project() {
     // TODO Check for unsaved changes before closing
     if (m_proj == nullptr) return;
-    parentWidget()->parentWidget()->setWindowTitle(QString::fromStdString(""));
+    set_main_window_name(QString::fromStdString(""));
     emit set_status_bar("Closing project");
     emit project_closed();
     emit remove_overlay();
@@ -656,7 +655,7 @@ void ProjectWidget::remove_project() {
     int reply = msg_box.exec();
 
     if (reply != QMessageBox::Yes) return;
-    parentWidget()->parentWidget()->setWindowTitle(QString::fromStdString(""));
+    set_main_window_name(QString::fromStdString(""));
     emit set_status_bar("Removing project and associated files");
 
     m_proj->delete_artifacts();
@@ -665,4 +664,8 @@ void ProjectWidget::remove_project() {
     m_proj = nullptr;
     emit project_closed();
     emit remove_overlay();
+}
+
+void ProjectWidget::set_main_window_name(QString name) {
+    parentWidget()->parentWidget()->setWindowTitle(name);
 }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -664,4 +664,5 @@ void ProjectWidget::remove_project() {
     delete m_proj;
     m_proj = nullptr;
     emit project_closed();
+    emit remove_overlay();
 }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -524,28 +524,27 @@ void ProjectWidget::remove_item() {
     delete_box.setDefaultButton(QMessageBox::No);
     if (delete_box.exec() == QMessageBox::Yes) {
         for (auto item : selectedItems()) {
+            qDebug() << "in for, selected items";
             if (item->type() == FOLDER_ITEM) {
-                //for ()
-
+                std::vector<VideoItem*> v_items;
+                get_video_items(item, v_items);
+                for (auto v_item : v_items) {
+                    emit item_removed(v_item->get_video_project());
+                }
             }
 
-            qDebug() << "in for";
-            if (item->type() == VIDEO_ITEM) {
+            else if (item->type() == VIDEO_ITEM) {
                 qDebug() << "is video";
                 VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
-                remove_video(vid_item);
+                emit item_removed(vid_item->get_video_project());
             }
-            //} else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
+            else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
+                qDebug() << "in tag or analysis";
+            }
             delete item;
         }
     }
     emit remove_overlay();
-    //emit project_closed();
-
-}
-
-void ProjectWidget::remove_video(VideoItem* vid_item) {
-    emit item_removed(vid_item->get_video_project());
 }
 
 /**

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -224,7 +224,7 @@ std::stack<int> ProjectWidget::get_index_path(QTreeWidgetItem *item){
 
 /**
  * @brief ProjectWidget::get_video_item
- * Searches the project tree for the VideoItem containing the VideoProjectt v_proj
+ * Searches the project tree for the VideoItem containing the VideoProject v_proj
  * @param v_proj    :   target VideoProject
  * @return VideoItem*   :   the correct VideoItem if found else nullptr
  */
@@ -524,11 +524,28 @@ void ProjectWidget::remove_item() {
     delete_box.setDefaultButton(QMessageBox::No);
     if (delete_box.exec() == QMessageBox::Yes) {
         for (auto item : selectedItems()) {
+            if (item->type() == FOLDER_ITEM) {
+                //for ()
+
+            }
+
+            qDebug() << "in for";
+            if (item->type() == VIDEO_ITEM) {
+                qDebug() << "is video";
+                VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
+                remove_video(vid_item);
+            }
+            //} else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
             delete item;
         }
     }
     emit remove_overlay();
+    //emit project_closed();
 
+}
+
+void ProjectWidget::remove_video(VideoItem* vid_item) {
+    emit item_removed(vid_item->get_video_project());
 }
 
 /**
@@ -616,6 +633,7 @@ void ProjectWidget::open_project(QString project_path) {
 void ProjectWidget::close_project() {
     // TODO Check for unsaved changes before closing
     if (m_proj == nullptr) return;
+    parentWidget()->parentWidget()->setWindowTitle(QString::fromStdString(""));
     emit set_status_bar("Closing project");
     emit project_closed();
     emit remove_overlay();
@@ -639,6 +657,7 @@ void ProjectWidget::remove_project() {
     int reply = msg_box.exec();
 
     if (reply != QMessageBox::Yes) return;
+    parentWidget()->parentWidget()->setWindowTitle(QString::fromStdString(""));
     emit set_status_bar("Removing project and associated files");
 
     m_proj->delete_artifacts();

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -88,8 +88,6 @@ private:
     void insert_to_path_index(VideoProject* vid_proj);
     void save_item_data(QTreeWidgetItem* item = nullptr);
     void add_analyses_to_item(VideoItem* v_item);
-
-    void remove_video(VideoItem* vid_item);
 signals:
     void project_closed();
     void item_removed(VideoProject* vid_proj);

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -76,6 +76,7 @@ private slots:
     void check_selection();
     void check_selection_level(QTreeWidgetItem* current, QTreeWidgetItem* prev);
 private:
+    void set_main_window_name(QString name);
     void tree_add_video();
     void tree_add_video(VideoProject* vid_proj, const QString& video_name);
     QStringList mimeTypes() const;

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -88,8 +88,11 @@ private:
     void insert_to_path_index(VideoProject* vid_proj);
     void save_item_data(QTreeWidgetItem* item = nullptr);
     void add_analyses_to_item(VideoItem* v_item);
+
+    void remove_video(VideoItem* vid_item);
 signals:
     void project_closed();
+    void item_removed(VideoProject* vid_proj);
 
 
 };

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -820,6 +820,7 @@ void VideoWidget::on_playback_slider_moved() {
  */
 void VideoWidget::load_marked_video(VideoProject* vid_proj) {
     int frame = -1;
+    if (!frame_wgt->isVisible()) frame_wgt->show();
     if (!video_btns_enabled) set_video_btns(true);
     if (m_vid_proj != vid_proj) {
         player_lock.lock();
@@ -861,6 +862,8 @@ void VideoWidget::clear_current_video() {
     playback_slider->setValue(frame);
     play_btn->setChecked(false);
     playback_slider->set_interval(-1, -1);
+    set_total_time(0);
+    frame_wgt->close();
 }
 
 void VideoWidget::set_video_btns(bool b) {

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -23,7 +23,7 @@
 VideoWidget::VideoWidget(QWidget *parent) : QWidget(parent), scroll_area(new DrawScrollArea) {
     // Init video controller
     v_controller = new VideoController(&frame_index, &is_playing, &new_frame,
-                                       &video_width, &video_height, &new_video, &new_frame_video, &v_sync,
+                                       &video_width, &video_height, &new_video, &new_frame_video, &video_loaded, &v_sync,
                                        &player_con, &player_lock, &m_video_path,
                                        &m_speed_step);
 
@@ -859,10 +859,16 @@ void VideoWidget::clear_current_video() {
     if (video_btns_enabled) set_video_btns(false);
     qDebug() << "disable butns";
 
+    player_lock.lock();
+    video_loaded.store(false);
+    player_lock.unlock();
+    player_con.notify_all();
+
     playback_slider->setValue(frame);
     play_btn->setChecked(false);
     playback_slider->set_interval(-1, -1);
     set_total_time(0);
+
     frame_wgt->close();
 }
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -851,9 +851,11 @@ void VideoWidget::remove_item(VideoProject* vid_proj) {
     if (get_current_video_project() == vid_proj) clear_current_video();
 }
 
+/**
+ * @brief VideoWidget::clear_current_video
+ * Removes the video from the videoplayer
+ */
 void VideoWidget::clear_current_video() {
-
-    //m_vid_proj == nullptr;
     qDebug() << "In Clear current video in vid_wg";
     int frame = -1;
     if (video_btns_enabled) set_video_btns(false);
@@ -873,10 +875,6 @@ void VideoWidget::clear_current_video() {
 }
 
 void VideoWidget::set_video_btns(bool b) {
-    if (b) {
-        qDebug() << "true";
-    } else qDebug() << "false";
-
     for (QPushButton* btn : btns) {
         btn->setEnabled(b);
     }

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -21,7 +21,7 @@
 
 
 VideoWidget::VideoWidget(QWidget *parent) : QWidget(parent), scroll_area(new DrawScrollArea) {
-    // Init video contoller
+    // Init video controller
     v_controller = new VideoController(&frame_index, &is_playing, &new_frame,
                                        &video_width, &video_height, &new_video, &new_frame_video, &v_sync,
                                        &player_con, &player_lock, &m_video_path,
@@ -820,7 +820,7 @@ void VideoWidget::on_playback_slider_moved() {
  */
 void VideoWidget::load_marked_video(VideoProject* vid_proj) {
     int frame = -1;
-    if (!video_btns_enabled) enable_video_btns();
+    if (!video_btns_enabled) set_video_btns(true);
     if (m_vid_proj != vid_proj) {
         player_lock.lock();
         m_video_path = vid_proj->get_video()->file_path;
@@ -845,14 +845,38 @@ void VideoWidget::load_marked_video(VideoProject* vid_proj) {
     }
 }
 
-void VideoWidget::enable_video_btns() {
-    for (QPushButton* btn : btns) {
-        btn->setEnabled(true);
-    }
-    playback_slider->setEnabled(true);
-    frame_line_edit->setEnabled(true);
-    speed_slider->setEnabled(true);
+void VideoWidget::remove_item(VideoProject* vid_proj) {
+    qDebug() << "Before if";
+    if (get_current_video_project() == vid_proj) clear_current_video();
 }
+
+void VideoWidget::clear_current_video() {
+
+    //m_vid_proj == nullptr;
+    qDebug() << "In Clear current video in vid_wg";
+    int frame = -1;
+    if (video_btns_enabled) set_video_btns(false);
+    qDebug() << "disable butns";
+
+    playback_slider->setValue(frame);
+    play_btn->setChecked(false);
+    playback_slider->set_interval(-1, -1);
+}
+
+void VideoWidget::set_video_btns(bool b) {
+    if (b) {
+        qDebug() << "true";
+    } else qDebug() << "false";
+
+    for (QPushButton* btn : btns) {
+        btn->setEnabled(b);
+    }
+    playback_slider->setEnabled(b);
+    frame_line_edit->setEnabled(b);
+    speed_slider->setEnabled(b);
+    video_btns_enabled = b;
+}
+
 
 void VideoWidget::enable_poi_btns(bool b, bool ana_play_btn) {
     next_poi_btn->setEnabled(b);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -847,7 +847,6 @@ void VideoWidget::load_marked_video(VideoProject* vid_proj) {
 }
 
 void VideoWidget::remove_item(VideoProject* vid_proj) {
-    qDebug() << "Before if";
     if (get_current_video_project() == vid_proj) clear_current_video();
 }
 
@@ -856,10 +855,8 @@ void VideoWidget::remove_item(VideoProject* vid_proj) {
  * Removes the video from the videoplayer
  */
 void VideoWidget::clear_current_video() {
-    qDebug() << "In Clear current video in vid_wg";
     int frame = -1;
     if (video_btns_enabled) set_video_btns(false);
-    qDebug() << "disable butns";
 
     player_lock.lock();
     video_loaded.store(false);

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -58,6 +58,7 @@ private:
     std::atomic_bool new_frame{false};          // True when a new frame has been loaded by the video player
     std::atomic_bool new_video{false};          // True when a new video is loaded
     std::atomic_bool new_frame_video{false};    // True when a new video has been loaded by video player but not by frameprocesser
+    std::atomic_bool video_loaded{false};       // True when a video is loaded/open
 
     std::condition_variable player_con;         // Used to notify the video player when to load a new video or when to play the current one
     std::mutex player_lock;

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -132,6 +132,8 @@ public slots:
     void on_playback_slider_moved(void);
 
     void load_marked_video(VideoProject* vid_proj);
+    void clear_current_video();
+    void remove_item(VideoProject* vid_proj);
 
     void set_current_frame_size(QSize size);
     void on_export_frame(void);
@@ -218,7 +220,7 @@ private:
     bool video_btns_enabled = false;
     bool analysis_only = false;
 
-    void enable_video_btns();
+    void set_video_btns(bool b);
 
     void init_control_buttons();
     void init_layouts();

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -128,6 +128,7 @@ void FrameProcessor::process_frame() {
     // Draws the overlay
     qDebug() << "draw overlay";
     m_overlay->draw_overlay(manipulated_frame, m_frame_index->load());
+    qDebug() << "overlay drawn";
 
     // Scales the frame
     qDebug() << "scale frame";

--- a/ViAn/Video/videocontroller.cpp
+++ b/ViAn/Video/videocontroller.cpp
@@ -5,7 +5,7 @@
 
 VideoController::VideoController(std::atomic<int>* frame_index, std::atomic_bool* is_playing,
                                  std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
-                                 std::atomic_bool* new_video, std::atomic_bool* new_frame_video,video_sync* v_sync, std::condition_variable* player_con,
+                                 std::atomic_bool* new_video, std::atomic_bool* new_frame_video, atomic_bool *video_loaded, video_sync* v_sync, std::condition_variable* player_con,
                                  std::mutex* player_lock, std::string* video_path, std::atomic_int* speed){
 
     m_frame = frame_index;
@@ -14,6 +14,7 @@ VideoController::VideoController(std::atomic<int>* frame_index, std::atomic_bool
     m_height = height;
     m_new_video = new_video;
     m_new_frame_video = new_frame_video;
+    m_video_loaded = video_loaded;
     m_v_sync = v_sync;
     m_new_frame = new_frame;
 
@@ -26,7 +27,7 @@ VideoController::VideoController(std::atomic<int>* frame_index, std::atomic_bool
 
 void VideoController::run() {
     VideoPlayer* v_player = new VideoPlayer(m_frame, m_is_playing, m_new_frame,
-                                            m_width, m_height, m_new_video, m_new_frame_video,
+                                            m_width, m_height, m_new_video, m_new_frame_video, m_video_loaded,
                                             m_v_sync, m_player_con, m_player_lock, m_video_path,
                                             m_speed);
 

--- a/ViAn/Video/videocontroller.h
+++ b/ViAn/Video/videocontroller.h
@@ -31,6 +31,7 @@ class VideoController : public QThread {
     std::atomic_bool* m_new_video;
     std::atomic_bool* m_new_frame_video;
     std::atomic_bool* m_new_frame;
+    std::atomic_bool* m_video_loaded;
 
     std::condition_variable* m_player_con;
     std::mutex* m_player_lock;
@@ -41,7 +42,7 @@ class VideoController : public QThread {
 public:
     VideoController(std::atomic<int>* frame_index, std::atomic_bool *is_playing,
                     std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
-                    std::atomic_bool* new_video, std::atomic_bool *new_frame_video, video_sync* v_sync, std::condition_variable* player_con,
+                    std::atomic_bool* new_video, std::atomic_bool *new_frame_video, std::atomic_bool* video_loaded, video_sync* v_sync, std::condition_variable* player_con,
                     std::mutex* player_lock, std::string* video_path, std::atomic_int* speed);
 
 

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -37,7 +37,7 @@ VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_pla
 
 void VideoPlayer::load_video(){
     m_video_loaded->store(true);
-    current_frame = -1; //<----
+    current_frame = -1;
     m_is_playing->store(false);
     m_frame->store(0);
     m_capture.open(*m_video_path);
@@ -73,8 +73,6 @@ void VideoPlayer::set_frame() {
     int frame_index = m_frame->load();
     if (frame_index >= 0 && frame_index <= m_last_frame) {
         m_capture.set(CV_CAP_PROP_POS_FRAMES, frame_index);
-        qDebug() << "set_frame";
-        qDebug() << frame_index;
         current_frame = frame_index;
         synced_read();
     }

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -5,7 +5,7 @@
 
 VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_playing,
                          std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
-                         std::atomic_bool* new_video, std::atomic_bool *new_frame_video, video_sync* v_sync, std::condition_variable* player_con,
+                         std::atomic_bool* new_video, std::atomic_bool *new_frame_video, std::atomic_bool *video_loaded, video_sync* v_sync, std::condition_variable* player_con,
                          std::mutex* player_lock, std::string* video_path,
                          std::atomic_int* speed_step, QObject *parent) : QObject(parent) {
 
@@ -18,6 +18,7 @@ VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_pla
     m_video_height = height;
     m_new_video = new_video;
     m_new_frame_video = new_frame_video;
+    m_video_loaded = video_loaded;
     m_v_sync = v_sync;
     m_player_con = player_con;
     m_player_lock = player_lock;
@@ -35,7 +36,8 @@ VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_pla
  */
 
 void VideoPlayer::load_video(){
-    current_frame = -1;
+    m_video_loaded->store(true);
+    current_frame = -1; //<----
     m_is_playing->store(false);
     m_frame->store(0);
     m_capture.open(*m_video_path);
@@ -70,9 +72,11 @@ void VideoPlayer::set_playback_speed(int speed_steps) {
 void VideoPlayer::set_frame() {
     int frame_index = m_frame->load();
     if (frame_index >= 0 && frame_index <= m_last_frame) {
-        m_capture.set(CV_CAP_PROP_POS_FRAMES, frame_index);        
-        synced_read();
+        m_capture.set(CV_CAP_PROP_POS_FRAMES, frame_index);
+        qDebug() << "set_frame";
+        qDebug() << frame_index;
         current_frame = frame_index;
+        synced_read();
     }
 }
 
@@ -86,14 +90,17 @@ void VideoPlayer::check_events() {
         std::unique_lock<std::mutex> lk(*m_player_lock);
         auto now = std::chrono::system_clock::now();
         auto delay = std::chrono::milliseconds{static_cast<int>(m_delay * speed_multiplier)};
-        if (m_player_con->wait_until(lk, now + delay - elapsed, [&](){return m_new_video->load() || current_frame != m_frame->load();})) {
+        if (m_player_con->wait_until(lk, now + delay - elapsed, [&](){return m_new_video->load() || (current_frame != m_frame->load() && m_video_loaded->load());})) {
             qDebug() << "";
             qDebug() << "in vid_play";
             // Notified from the VideoWidget
             if (m_new_video->load()) {
                 qDebug() << "wait load read video";
                 wait_load_read();
-            } else if (current_frame != m_frame->load()) {
+            } else if (current_frame != m_frame->load() && m_video_loaded->load()) {
+                qDebug() << "curr: ";
+                qDebug() << current_frame;
+                qDebug() << m_frame->load();
                 set_frame();
             }
         } else {
@@ -173,7 +180,6 @@ bool VideoPlayer::wait_load_read(){
             return false;
         }
         m_new_frame->store(true);
-        qDebug() << "new frame";
     }
     m_v_sync->con_var.notify_one();
     return true;

--- a/ViAn/Video/videoplayer.h
+++ b/ViAn/Video/videoplayer.h
@@ -44,6 +44,7 @@ class VideoPlayer : public QObject{
     std::atomic_int* m_speed_step;
     std::atomic_bool* m_new_frame;
     std::atomic_bool* m_new_video;
+    std::atomic_bool* m_video_loaded;
 
     video_sync* m_v_sync;
 
@@ -53,7 +54,6 @@ class VideoPlayer : public QObject{
 
     // Player state
     std::atomic_bool* m_is_playing;
-    bool m_video_loaded = false;
     bool m_playback_status = false;
     int m_cur_speed_step = 1;
     double speed_multiplier = 1;
@@ -67,7 +67,7 @@ class VideoPlayer : public QObject{
 public:
     explicit VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool* is_playing,
                          std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
-                         std::atomic_bool* new_video, std::atomic_bool* new_frame_video, video_sync* v_sync, std::condition_variable* player_con,
+                         std::atomic_bool* new_video, std::atomic_bool* new_frame_video, std::atomic_bool* video_loaded, video_sync* v_sync, std::condition_variable* player_con,
                          std::mutex* player_lock, std::string* video_path,
                          std::atomic_int* speed_step, QObject *parent = nullptr);
 

--- a/ViAn/Video/videoplayer.h
+++ b/ViAn/Video/videoplayer.h
@@ -67,7 +67,7 @@ class VideoPlayer : public QObject{
 public:
     explicit VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool* is_playing,
                          std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
-                         std::atomic_bool* new_video,std::atomic_bool* new_frame_video, video_sync* v_sync, std::condition_variable* player_con,
+                         std::atomic_bool* new_video, std::atomic_bool* new_frame_video, video_sync* v_sync, std::condition_variable* player_con,
                          std::mutex* player_lock, std::string* video_path,
                          std::atomic_int* speed_step, QObject *parent = nullptr);
 
@@ -82,8 +82,8 @@ public slots:
     void set_frame();
     void check_events(void);
 private:
-    void load_video();
     void load_video_info();
+    void load_video();
     bool synced_read();
     bool wait_load_read();
     void set_playback_speed(int speed_steps);


### PR DESCRIPTION
Fixed the crash that happened when closing or removing a project and the opening a new one and played a video. Now the videobuttons are disabled when there's not a video to play. Also the framewidget will be closed when no video is loaded.