### PR TITLE
Recent project window

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -15,8 +15,6 @@
 #include "Video/shapes/shape.h"
 #include "Analysis/motiondetection.h"
 #include "Analysis/analysismethod.h"
-#include "Toolbars/maintoolbar.h"
-#include "Toolbars/drawingtoolbar.h"
 #include "manipulatordialog.h"
 #include "GUI/frameexporterdialog.h"
 
@@ -75,7 +73,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     init_help_menu();
 
     // Main toolbar
-    MainToolbar* main_toolbar = new MainToolbar();
+    main_toolbar = new MainToolbar();
     main_toolbar->setWindowTitle(tr("Main toolbar"));
     addToolBar(main_toolbar);
     connect(main_toolbar->add_video_act, &QAction::triggered, project_wgt, &ProjectWidget::add_video);
@@ -83,9 +81,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(main_toolbar->open_act, &QAction::triggered, this, &MainWindow::open_project_dialog);
 
     // Draw toolbar
-    DrawingToolbar* draw_toolbar = new DrawingToolbar();
+    draw_toolbar = new DrawingToolbar();
     draw_toolbar->setWindowTitle(tr("Draw toolbar"));
-    QAction* toggle_draw_toolbar = draw_toolbar->toggleViewAction();
+    toggle_draw_toolbar = draw_toolbar->toggleViewAction();
     addToolBar(draw_toolbar);
     connect(main_toolbar->toggle_draw_toolbar_act, &QAction::triggered, toggle_draw_toolbar, &QAction::trigger);   
     connect(draw_toolbar, SIGNAL(set_color(QColor)), video_wgt->frame_wgt, SLOT(set_overlay_color(QColor)));

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -26,6 +26,7 @@
  * @param parent a QWidget variable
  */
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
+    setWindowTitle("ViAn - Create a project to get started");
     QDockWidget* project_dock = new QDockWidget(tr("Projects"), this);
     QDockWidget* bookmark_dock = new QDockWidget(tr("Bookmarks"), this);
     project_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
@@ -121,6 +122,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
 
     connect(project_wgt, SIGNAL(enable_poi_btns(bool,bool)), video_wgt, SLOT(enable_poi_btns(bool,bool)));
     connect(project_wgt, SIGNAL(enable_tag_btn(bool)), video_wgt, SLOT(enable_tag_btn(bool)));
+    connect(project_wgt, SIGNAL(enable_menu_items(bool)), this, SLOT(enable_project_tools(bool)));
 
     connect(project_wgt, SIGNAL(set_poi_slider(bool)), video_wgt->playback_slider, SLOT(set_show_pois(bool)));
     connect(project_wgt, SIGNAL(set_tag_slider(bool)), video_wgt->playback_slider, SLOT(set_show_tags(bool)));
@@ -141,6 +143,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(rp_dialog, &RecentProjectDialog::new_project, project_wgt, &ProjectWidget::new_project);
     connect(rp_dialog, &RecentProjectDialog::open_project_from_file, this, &MainWindow::open_project_dialog);
     QTimer::singleShot(0, rp_dialog, SLOT(exec()));
+
+    enable_project_tools(false);
 }
 
 
@@ -156,17 +160,17 @@ MainWindow::~MainWindow() {
  * Set up the file menu
  */
 void MainWindow::init_file_menu() {
-    QMenu* file_menu = menuBar()->addMenu(tr("&File"));
+    file_menu = menuBar()->addMenu(tr("&File"));
 
     // Init actions
-    QAction* new_project_act = new QAction(tr("&New project"), this);
-    QAction* add_vid_act = new QAction(tr("&Add video"), this);
-    QAction* open_project_act = new QAction(tr("&Open project"), this);
-    QAction* save_project_act = new QAction(tr("&Save project"), this);
-    QAction* gen_report_act = new QAction(tr("&Generate report"), this);
-    QAction* close_project_act = new QAction(tr("&Close project"), this);
-    QAction* remove_project_act = new QAction(tr("&Remove project"), this);
-    QAction* quit_act = new QAction(tr("&Quit"), this);
+    new_project_act = new QAction(tr("&New project"), this);
+    add_vid_act = new QAction(tr("&Add video"), this);
+    open_project_act = new QAction(tr("&Open project"), this);
+    save_project_act = new QAction(tr("&Save project"), this);
+    gen_report_act = new QAction(tr("&Generate report"), this);
+    close_project_act = new QAction(tr("&Close project"), this);
+    remove_project_act = new QAction(tr("&Remove project"), this);
+    quit_act = new QAction(tr("&Quit"), this);
 
     // Set icons
     //new_project_act->setIcon(QIcon("../ViAn/Icons/....png"));     //add if wanted
@@ -226,12 +230,12 @@ void MainWindow::init_file_menu() {
  * Set up the edit menu
  */
 void MainWindow::init_edit_menu() {
-    QMenu* edit_menu = menuBar()->addMenu(tr("&Edit"));
+    edit_menu = menuBar()->addMenu(tr("&Edit"));
 
-    QAction* cont_bri_act = new QAction(tr("&Contrast/Brightness"), this);
-    QAction* cw_act = new QAction(tr("&Rotate 90°"), this);
-    QAction* ccw_act = new QAction(tr("Ro&tate 90°"), this);
-    QAction* options_act = new QAction(tr("&Options"), this);
+    cont_bri_act = new QAction(tr("&Contrast/Brightness"), this);
+    cw_act = new QAction(tr("&Rotate 90°"), this);
+    ccw_act = new QAction(tr("Ro&tate 90°"), this);
+    options_act = new QAction(tr("&Options"), this);
 
     cont_bri_act->setIcon(QIcon("../ViAn/Icons/screen.png"));
     cw_act->setIcon(QIcon("../ViAn/Icons/right.png"));
@@ -260,7 +264,7 @@ void MainWindow::init_edit_menu() {
  * Set up the view menu
  */
 void MainWindow::init_view_menu() {
-    QMenu* view_menu = menuBar()->addMenu(tr("&View"));
+    view_menu = menuBar()->addMenu(tr("&View"));
 
     detect_intv_act = new QAction(tr("&Detection intervals"), this);      //Slider pois
     bound_box_act = new QAction(tr("&Bounding boxes"), this);        //Video oois
@@ -314,21 +318,22 @@ void MainWindow::init_view_menu() {
  * Set up the analysis menu
  */
 void MainWindow::init_analysis_menu() {
-    QMenu* analysis_menu = menuBar()->addMenu(tr("&Analysis"));
+    analysis_menu = menuBar()->addMenu(tr("&Analysis"));
 
-    QAction* analysis_act = new QAction(tr("&Perform analysis"), this);
+    analysis_act = new QAction(tr("&Perform analysis"), this);
     analysis_act->setIcon(QIcon("../ViAn/Icons/analysis.png"));
     analysis_act->setStatusTip(tr("Perform analysis"));
     analysis_menu->addAction(analysis_act);
+
     connect(analysis_act, &QAction::triggered, project_wgt, &ProjectWidget::advanced_analysis);
 }
 
 void MainWindow::init_interval_menu() {
-    QMenu* interval_menu = menuBar()->addMenu(tr("&Interval"));
+    interval_menu = menuBar()->addMenu(tr("&Interval"));
 
-    QAction* tag_interval_act = new QAction(tr("&Tag interval"), this);
-    QAction* rm_tag_interval_act = new QAction(tr("&Remove tag on interval"), this);
-    QAction* rm_interval_act = new QAction(tr("&Delete interval"), this);
+    tag_interval_act = new QAction(tr("&Tag interval"), this);
+    rm_tag_interval_act = new QAction(tr("&Remove tag on interval"), this);
+    rm_interval_act = new QAction(tr("&Delete interval"), this);
 
     tag_interval_act->setShortcut(tr("Shift+T"));
     rm_tag_interval_act->setShortcut(tr("Shift+R"));
@@ -348,25 +353,25 @@ void MainWindow::init_interval_menu() {
  * Set up the tools menu
  */
 void MainWindow::init_tools_menu() {
-    QMenu* tool_menu = menuBar()->addMenu(tr("&Tools"));
+    tool_menu = menuBar()->addMenu(tr("&Tools"));
 
-    QAction* zoom_in_act = new QAction(tr("&Zoom in"), this);
+    zoom_in_act = new QAction(tr("&Zoom in"), this);
     color_act = new QAction(tr("&Color"), this);
-    QAction* zoom_out_act = new QAction(tr("Zoom &out"), this);
-    QAction* fit_screen_act = new QAction(tr("&Fit to screen"), this);
-    QAction* reset_zoom_act = new QAction(tr("Re&set zoom"), this);
-    QAction* rectangle_act = new QAction(tr("&Rectangle"), this);
-    QAction* circle_act = new QAction(tr("C&ircle"), this);
-    QAction* line_act = new QAction(tr("Li&ne"), this);
-    QAction* arrow_act = new QAction(tr("&Arrow"), this);
-    QAction* pen_act = new QAction(tr("&Pen"), this);
-    QAction* text_act = new QAction(tr("&Text"), this);
+    zoom_out_act = new QAction(tr("Zoom &out"), this);
+    fit_screen_act = new QAction(tr("&Fit to screen"), this);
+    reset_zoom_act = new QAction(tr("Re&set zoom"), this);
+    rectangle_act = new QAction(tr("&Rectangle"), this);
+    circle_act = new QAction(tr("C&ircle"), this);
+    line_act = new QAction(tr("Li&ne"), this);
+    arrow_act = new QAction(tr("&Arrow"), this);
+    pen_act = new QAction(tr("&Pen"), this);
+    text_act = new QAction(tr("&Text"), this);
 
-    QAction* export_act = new QAction(tr("&Export interval"), this);
+    export_act = new QAction(tr("&Export interval"), this);
     export_act->setShortcut(tr("Shift+E"));
-    QAction* undo_act = new QAction(tr("&Undo"), this);
-    QAction* redo_act = new QAction(tr("Re&do"), this);
-    QAction* clear_act = new QAction(tr("C&lear"), this);
+    undo_act = new QAction(tr("&Undo"), this);
+    redo_act = new QAction(tr("Re&do"), this);
+    clear_act = new QAction(tr("C&lear"), this);
 
     color_act->setIcon(QIcon("../ViAn/Icons/color.png"));
     zoom_in_act->setIcon(QIcon("../ViAn/Icons/zoom_in.png"));
@@ -384,13 +389,13 @@ void MainWindow::init_tools_menu() {
     clear_act->setIcon(QIcon("../ViAn/Icons/clear.png"));
 
     // Export submenu
-    QMenu* export_menu = tool_menu->addMenu(tr("&Export"));
+    export_menu = tool_menu->addMenu(tr("&Export"));
     export_menu->addAction(export_act);
 
     tool_menu->addSeparator();
 
     tool_menu->addAction(color_act);
-    QMenu* drawing_tools = tool_menu->addMenu(tr("&Shapes"));
+    drawing_tools = tool_menu->addMenu(tr("&Shapes"));
     drawing_tools->addAction(rectangle_act);
     drawing_tools->addAction(circle_act);
     drawing_tools->addAction(line_act);
@@ -447,8 +452,8 @@ void MainWindow::init_tools_menu() {
  * Set up the help menu
  */
 void MainWindow::init_help_menu() {
-    QMenu* help_menu = menuBar()->addMenu(tr("&Help"));
-    QAction* help_act = new QAction(tr("Open manual"), this);
+    help_menu = menuBar()->addMenu(tr("&Help"));
+    help_act = new QAction(tr("Open manual"), this);
     help_act->setIcon(QIcon("../ViAn/Icons/question.png"));
     help_menu->addAction(help_act);
     help_act->setShortcut(tr("Ctrl+h"));
@@ -572,4 +577,39 @@ void MainWindow::options() {
 void MainWindow::open_project_dialog(){
     QString project_path = QFileDialog().getOpenFileName(this, tr("Open project"), QDir::homePath());
     open_project(project_path);
+}
+
+/**
+ * @brief MainWindow::enable_project_tools
+ * @param b
+ * Enable/disable the actions in the menus that needs a project to function
+ */
+void MainWindow::enable_project_tools(bool b) {
+    add_vid_act->setEnabled(b);
+    save_project_act->setEnabled(b);
+    close_project_act->setEnabled(b);
+    remove_project_act->setEnabled(b);
+    gen_report_act->setEnabled(b);
+    cont_bri_act->setEnabled(b);
+    cw_act->setEnabled(b);
+    ccw_act->setEnabled(b);
+    analysis_act->setEnabled(b);
+    tag_interval_act->setEnabled(b);
+    rm_tag_interval_act->setEnabled(b);
+    rm_interval_act->setEnabled(b);
+    export_act->setEnabled(b);
+    color_act->setEnabled(b);
+    rectangle_act->setEnabled(b);
+    circle_act->setEnabled(b);
+    line_act->setEnabled(b);
+    arrow_act->setEnabled(b);
+    pen_act->setEnabled(b);
+    text_act->setEnabled(b);
+    undo_act->setEnabled(b);
+    redo_act->setEnabled(b);
+    clear_act->setEnabled(b);
+    zoom_in_act->setEnabled(b);
+    zoom_out_act->setEnabled(b);
+    fit_screen_act->setEnabled(b);
+    reset_zoom_act->setEnabled(b);
 }

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -25,6 +25,8 @@
 #include "Analysis/analysiswidget.h"
 #include "Bookmark/bookmarkwidget.h"
 #include "statusbar.h"
+#include "Toolbars/maintoolbar.h"
+#include "Toolbars/drawingtoolbar.h"
 
 using namespace std;
 class AnalysisWindow;
@@ -131,6 +133,10 @@ private:
     QMenu* export_menu;
     QMenu* drawing_tools;
     QMenu* help_menu;
+
+    MainToolbar* main_toolbar;
+    DrawingToolbar* draw_toolbar;
+    QAction* toggle_draw_toolbar;
 
     void init_file_menu();
     void init_edit_menu();

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -39,13 +39,6 @@ public:
     ~MainWindow();
 
     StatusBar* status_bar;
-    QAction* show_analysis_queue;
-    QAction* detect_intv_act;
-    QAction* bound_box_act;
-    QAction* interval_act;
-    QAction* drawing_act;
-
-    QAction* color_act;
 
     RecentProjectDialog* rp_dialog;
 
@@ -68,6 +61,7 @@ private slots:
 public slots:
     void options(void);
     void open_project_dialog();
+    void enable_project_tools(bool b);
 
 signals:
     void set_status_bar(QString);
@@ -80,10 +74,63 @@ private:
     AnalysisWidget* analysis_wgt;
     BookmarkWidget* bookmark_wgt;
 
+    AnalysisWindow *analysis_window;
+
+    QAction* new_project_act;
+    QAction* add_vid_act;
+    QAction* open_project_act;
+    QAction* save_project_act;
+    QAction* close_project_act;
+    QAction* remove_project_act;
+    QAction* gen_report_act;
+    QAction* quit_act;
+
+    QAction* cont_bri_act;
+    QAction* cw_act;
+    QAction* ccw_act;
+    QAction* options_act;
+
     QAction* toggle_project_wgt;
     QAction* toggle_bookmark_wgt;
+    QAction* detect_intv_act;
+    QAction* bound_box_act;
+    QAction* interval_act;
+    QAction* drawing_act;
+    QAction* show_analysis_queue;
 
-    AnalysisWindow *analysis_window;
+    QAction* analysis_act;
+
+    QAction* tag_interval_act;
+    QAction* rm_tag_interval_act;
+    QAction* rm_interval_act;
+
+    QAction* export_act;
+    QAction* color_act;
+    QAction* rectangle_act;
+    QAction* circle_act;
+    QAction* line_act;
+    QAction* arrow_act;
+    QAction* pen_act;
+    QAction* text_act;
+    QAction* undo_act;
+    QAction* redo_act;
+    QAction* clear_act;
+    QAction* zoom_in_act;
+    QAction* zoom_out_act;
+    QAction* fit_screen_act;
+    QAction* reset_zoom_act;
+
+    QAction* help_act;
+
+    QMenu* file_menu;
+    QMenu* edit_menu;
+    QMenu* view_menu;
+    QMenu* analysis_menu;
+    QMenu* interval_menu;
+    QMenu* tool_menu;
+    QMenu* export_menu;
+    QMenu* drawing_tools;
+    QMenu* help_menu;
 
     void init_file_menu();
     void init_edit_menu();

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -63,6 +63,7 @@ void ProjectWidget::add_project(QString project_name, QString project_path) {
     m_proj->save_project();
     _tmp_path.append(_tmp_name);
     emit proj_path(m_proj->getDir());
+    emit enable_menu_items(true);
 }
 
 /**
@@ -71,7 +72,10 @@ void ProjectWidget::add_project(QString project_name, QString project_path) {
  * Creates a file dialog and creates a video project based on file path
  */
 void ProjectWidget::add_video() {
-    if (m_proj == nullptr)  return;
+    if (m_proj == nullptr) {
+        emit set_status_bar("No project found. Please create or open a project first.");
+        return;
+    }
     // TODO: HANDLE CASE. Only open video files
     QStringList video_paths = QFileDialog().getOpenFileNames(this, tr("Add video"), m_proj->getDir().c_str());
     for (auto video_path : video_paths){
@@ -574,7 +578,10 @@ void ProjectWidget::create_folder_item() {
  * Slot function to save the open project
  */
 void ProjectWidget::save_project() {
-    if (m_proj == nullptr ) return;
+    if (m_proj == nullptr) {
+        emit set_status_bar("No project found. Please create or open a project first.");
+        return;
+    }
     save_item_data();
     ProjectTreeState tree_state;
     tree_state.set_tree(invisibleRootItem());
@@ -607,6 +614,7 @@ void ProjectWidget::open_project(QString project_path) {
         insert_to_path_index(vid_proj);
         emit load_bookmarks(vid_proj);
     }
+    emit enable_menu_items(true);
 }
 
 /**
@@ -615,10 +623,14 @@ void ProjectWidget::open_project(QString project_path) {
  */
 void ProjectWidget::close_project() {
     // TODO Check for unsaved changes before closing
-    if (m_proj == nullptr) return;
+    if (m_proj == nullptr) {
+        emit set_status_bar("No project found. Please create or open a project first.");
+        return;
+    }
     emit set_status_bar("Closing project");
     emit project_closed();
     emit remove_overlay();
+    emit enable_menu_items(false);
     this->clear();
     delete m_proj;
     m_proj = nullptr;
@@ -630,7 +642,10 @@ void ProjectWidget::close_project() {
  */
 void ProjectWidget::remove_project() {
     // TODO Does this delete all images?
-    if (m_proj == nullptr) return;
+    if (m_proj == nullptr) {
+        emit set_status_bar("No project found. Please create or open a project first.");
+        return;
+    }
     QMessageBox msg_box;
     msg_box.setText("Are you sure you want to remove the project?");
     msg_box.setInformativeText("This will delete all project files (images, reports, etc).");
@@ -646,4 +661,5 @@ void ProjectWidget::remove_project() {
     delete m_proj;
     m_proj = nullptr;
     emit project_closed();
+    emit enable_menu_items(false);
 }

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -44,6 +44,7 @@ signals:
     void set_detections(bool);
     void enable_poi_btns(bool, bool);
     void enable_tag_btn(bool);
+    void enable_menu_items(bool);
     void set_poi_slider(bool);
     void set_tag_slider(bool);
     void set_status_bar(QString);

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -18,10 +18,13 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
 
     new_btn = new QPushButton(tr("New project"));
     new_btn->setToolTip(tr("Start a new project"));
-    open_btn = new QPushButton(tr("Open project"));
-    open_btn->setToolTip(tr("Open a project from file"));
-    v_btn_layout->addWidget(new_btn);                           // Second row second col first row
-    v_btn_layout->addWidget(open_btn);                          // Second row second col second row
+    open_other_btn = new QPushButton(tr("Open project..."));
+    open_other_btn->setToolTip(tr("Open a project from file"));
+    confirm_btn = new QPushButton(tr("Open"));
+    confirm_btn->setToolTip(tr("Open selected project"));
+    v_btn_layout->addWidget(new_btn);                                 // Second row second col first row
+    v_btn_layout->addWidget(open_other_btn);                          // Second row second col second row
+    v_btn_layout->addWidget(confirm_btn);                          // Second row second col third row
 
     for (auto project : RecentProject().load_recent()) {
         QListWidgetItem* item = new QListWidgetItem(QString::fromStdString(project.first));
@@ -31,7 +34,8 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
 
     connect(recent_list, &QListWidget::itemDoubleClicked, this, &RecentProjectDialog::on_item_double_clicked);
     connect(new_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_new_btn_clicked);
-    connect(open_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_open_btn_clicked);
+    connect(open_other_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_open_btn_clicked);
+    connect(confirm_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_confirm_btn_clicked);
 }
 
 /**
@@ -49,8 +53,8 @@ void RecentProjectDialog::on_item_double_clicked(QListWidgetItem* item) {
  * Accepts dialog and emits signal to create a new project
  */
 void RecentProjectDialog::on_new_btn_clicked(){
-    accept();
     new_project();
+    accept();
 }
 
 /**
@@ -60,4 +64,10 @@ void RecentProjectDialog::on_new_btn_clicked(){
 void RecentProjectDialog::on_open_btn_clicked(){
     accept();
     open_project_from_file();
+}
+
+void RecentProjectDialog::on_confirm_btn_clicked(){
+    if (recent_list->selectedItems().length() == 0) return;
+    open_project(recent_list->currentItem()->toolTip());
+    accept();
 }

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -66,6 +66,10 @@ void RecentProjectDialog::on_open_btn_clicked(){
     open_project_from_file();
 }
 
+/**
+ * @brief RecentProjectDialog::on_confirm_btn_clicked
+ * Accepts dialog and emits signal to open the selected project
+ */
 void RecentProjectDialog::on_confirm_btn_clicked(){
     if (recent_list->selectedItems().length() == 0) return;
     open_project(recent_list->currentItem()->toolTip());

--- a/ViAn/GUI/recentprojectdialog.h
+++ b/ViAn/GUI/recentprojectdialog.h
@@ -23,7 +23,8 @@ class RecentProjectDialog : public QDialog {
     QVBoxLayout* v_main_layout;
     QVBoxLayout* v_btn_layout;
     QPushButton* new_btn;
-    QPushButton* open_btn;
+    QPushButton* open_other_btn;
+    QPushButton* confirm_btn;
     QListWidget* recent_list;
 public:
     RecentProjectDialog(QWidget* parent = nullptr);
@@ -35,6 +36,7 @@ private slots:
     void on_item_double_clicked(QListWidgetItem* item);
     void on_new_btn_clicked();
     void on_open_btn_clicked();
+    void on_confirm_btn_clicked();
 };
 
 #endif // RECENTPROJECTDIALOG_H


### PR DESCRIPTION
Made the recent projects-window a little more intuitive by adding a new button. This new button will open the selected project. you can still double click to open it but now there's also a button. Aside from that I also disabled most of the actions in the menus when there's not a project loaded. This because, firstly, you didn't need those options since you couldn't use them and secondly since it's now much easier to understand that you have to create or open a project to do anything since nothing else works.