### PR TITLE
Queue widget is now a dockable

### DIFF
--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -85,14 +85,12 @@ void AnalysisWidget::analysis_done(AnalysisProxy analysis) {
     emit remove_analysis_bar();
 }
 
-void AnalysisWidget::abort_analysis()
-{
+void AnalysisWidget::abort_analysis() {
     bool* abort = abort_map.at(current_method);
     *abort = true;
 }
 
-void AnalysisWidget::on_analysis_aborted()
-{    
+void AnalysisWidget::on_analysis_aborted() {
     analysis_queue.pop_front();
     delete current_analysis_item; // Delete item from tree
     auto it = abort_map.find(current_method);   
@@ -107,6 +105,7 @@ void AnalysisWidget::on_analysis_aborted()
     }
     // Queue Empty
     queue_wgt->hide();
+    //queue_wgt->toggle_show();
     emit remove_analysis_bar();
 }
 

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -5,12 +5,12 @@
 #include <QTreeWidgetItem>
 #include <tuple>
 AnalysisWidget::AnalysisWidget(QWidget *parent) : QWidget(parent){
-    //m_queue_wgt = new QueueWidget();
-    //m_queue_wgt->hide();
+
 }
 
 void AnalysisWidget::set_queue_wgt(QueueWidget *queue_wgt){
     m_queue_wgt = queue_wgt;
+
     connect(m_queue_wgt, SIGNAL(abort_analysis()), this, SLOT(abort_analysis()));
 }
 
@@ -24,6 +24,7 @@ void AnalysisWidget::set_queue_wgt(QueueWidget *queue_wgt){
 void AnalysisWidget::start_analysis(QTreeWidgetItem* item, AnalysisMethod *method) {
     tuple<AnalysisMethod*,QTreeWidgetItem*> analys (method,item);
     m_queue_wgt->enqueue(method);
+    m_queue_wgt->show();
     if (!analysis_queue.empty()) {
         analysis_queue.push_back(analys);        
         std::string name = "Queued #"+to_string(analysis_queue.size()-1);
@@ -109,7 +110,6 @@ void AnalysisWidget::on_analysis_aborted() {
     }
     // Queue Empty
     m_queue_wgt->hide();
-    //queue_wgt->toggle_show();
     emit remove_analysis_bar();
 }
 

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -5,9 +5,13 @@
 #include <QTreeWidgetItem>
 #include <tuple>
 AnalysisWidget::AnalysisWidget(QWidget *parent) : QWidget(parent){
-    queue_wgt = new QueueWidget();
-    queue_wgt->hide();
-    connect(queue_wgt, SIGNAL(abort_analysis()), this, SLOT(abort_analysis()));
+    //m_queue_wgt = new QueueWidget();
+    //m_queue_wgt->hide();
+}
+
+void AnalysisWidget::set_queue_wgt(QueueWidget *queue_wgt){
+    m_queue_wgt = queue_wgt;
+    connect(m_queue_wgt, SIGNAL(abort_analysis()), this, SLOT(abort_analysis()));
 }
 
 /**
@@ -19,13 +23,13 @@ AnalysisWidget::AnalysisWidget(QWidget *parent) : QWidget(parent){
  */
 void AnalysisWidget::start_analysis(QTreeWidgetItem* item, AnalysisMethod *method) {
     tuple<AnalysisMethod*,QTreeWidgetItem*> analys (method,item);
-    queue_wgt->enqueue(method);
+    m_queue_wgt->enqueue(method);
     if (!analysis_queue.empty()) {
         analysis_queue.push_back(analys);        
         std::string name = "Queued #"+to_string(analysis_queue.size()-1);
         emit name_in_tree(item, QString::fromStdString(name));
     } else {
-        queue_wgt->next();
+        m_queue_wgt->next();
         analysis_queue.push_back(analys);
         perform_analysis(analys);
         current_analysis_item = item;
@@ -51,7 +55,7 @@ void AnalysisWidget::perform_analysis(tuple<AnalysisMethod*, QTreeWidgetItem*> a
     connect(method, &AnalysisMethod::finished_analysis, this, &AnalysisWidget::analysis_done);
     QThreadPool::globalInstance()->start(method);
     emit add_analysis_bar();
-    queue_wgt->show();
+    m_queue_wgt->show();
 }
 
 /**
@@ -74,13 +78,13 @@ void AnalysisWidget::analysis_done(AnalysisProxy analysis) {
     duration = 0;
 
 
-    queue_wgt->next();
+    m_queue_wgt->next();
     if (!analysis_queue.empty()) {
         current_analysis_item = get<1>(analysis_queue.front());
         move_queue();
         perform_analysis(analysis_queue.front());
     }else{
-        queue_wgt->hide();
+        m_queue_wgt->hide();
     }
     emit remove_analysis_bar();
 }
@@ -96,7 +100,7 @@ void AnalysisWidget::on_analysis_aborted() {
     auto it = abort_map.find(current_method);   
     abort_map.erase(it);
 
-    queue_wgt->next();
+    m_queue_wgt->next();
     if (!analysis_queue.empty()) {        
         current_analysis_item = get<1>(analysis_queue.front());
         move_queue();
@@ -104,7 +108,7 @@ void AnalysisWidget::on_analysis_aborted() {
         return;
     }
     // Queue Empty
-    queue_wgt->hide();
+    m_queue_wgt->hide();
     //queue_wgt->toggle_show();
     emit remove_analysis_bar();
 }
@@ -135,7 +139,7 @@ void AnalysisWidget::send_progress(int progress) {
             dots += ".";
         }
     }
-    queue_wgt->update_progress(progress);
+    m_queue_wgt->update_progress(progress);
     std::string name = "Loading " + to_string(progress) + "%" + dots;
     emit name_in_tree(current_analysis_item, QString::fromStdString(name));
     emit show_progress(progress);

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -24,7 +24,7 @@ void AnalysisWidget::set_queue_wgt(QueueWidget *queue_wgt){
 void AnalysisWidget::start_analysis(QTreeWidgetItem* item, AnalysisMethod *method) {
     tuple<AnalysisMethod*,QTreeWidgetItem*> analys (method,item);
     m_queue_wgt->enqueue(method);
-    m_queue_wgt->show();
+    emit show_analysis_queue(true);
     if (!analysis_queue.empty()) {
         analysis_queue.push_back(analys);        
         std::string name = "Queued #"+to_string(analysis_queue.size()-1);
@@ -56,7 +56,7 @@ void AnalysisWidget::perform_analysis(tuple<AnalysisMethod*, QTreeWidgetItem*> a
     connect(method, &AnalysisMethod::finished_analysis, this, &AnalysisWidget::analysis_done);
     QThreadPool::globalInstance()->start(method);
     emit add_analysis_bar();
-    m_queue_wgt->show();
+    emit show_analysis_queue(true);
 }
 
 /**
@@ -85,7 +85,7 @@ void AnalysisWidget::analysis_done(AnalysisProxy analysis) {
         move_queue();
         perform_analysis(analysis_queue.front());
     }else{
-        m_queue_wgt->hide();
+        emit show_analysis_queue(false);
     }
     emit remove_analysis_bar();
 }
@@ -109,7 +109,7 @@ void AnalysisWidget::on_analysis_aborted() {
         return;
     }
     // Queue Empty
-    m_queue_wgt->hide();
+    emit show_analysis_queue(false);
     emit remove_analysis_bar();
 }
 

--- a/ViAn/GUI/Analysis/analysiswidget.h
+++ b/ViAn/GUI/Analysis/analysiswidget.h
@@ -79,6 +79,9 @@ signals:
 
     // Set analysis name in project tree
     void name_in_tree(QTreeWidgetItem*, QString);
+
+    // Show or hide the analysis queue window
+    void show_analysis_queue(bool);
 };
 
 #endif // ANALYSISWIDGET_H

--- a/ViAn/GUI/Analysis/analysiswidget.h
+++ b/ViAn/GUI/Analysis/analysiswidget.h
@@ -36,7 +36,7 @@ public:
     std::deque<tuple<AnalysisMethod*,QTreeWidgetItem*>> analysis_queue;
 
     // Widget representing the current analysis queue
-    QueueWidget* queue_wgt;
+    QueueWidget* m_queue_wgt;
 
     // Item in project tree corresponding to
     // the currently executing method
@@ -51,6 +51,7 @@ private:
     // Moves the queue forward
     void move_queue();
 public slots:
+    void set_queue_wgt(QueueWidget* queue_wgt);
 
     // Incoming request to start analysis
     void start_analysis(QTreeWidgetItem* item, AnalysisMethod *method);

--- a/ViAn/GUI/Analysis/queuewidget.cpp
+++ b/ViAn/GUI/Analysis/queuewidget.cpp
@@ -28,6 +28,9 @@ QueueWidget::QueueWidget(QWidget *parent) : QWidget(parent) {
     // Add queue
     layout->addWidget(m_queue);    
     setLayout(layout);
+    if(m_queue->count() == 0){
+        abort_btn->hide();
+    }
     // Show widget
     show();
 }
@@ -37,8 +40,7 @@ QueueWidget::QueueWidget(QWidget *parent) : QWidget(parent) {
  * Move queue forward if queue non empty,
  * otherwise reset current analysis representation
  */
-void QueueWidget::next()
-{
+void QueueWidget::next() {
     QListWidgetItem* item;
     m_line->setText(QString(""));
     progressbar->setValue(0);
@@ -56,8 +58,7 @@ void QueueWidget::next()
  * @param method
  * Add method to back of queue
  */
-void QueueWidget::enqueue(AnalysisMethod *method)
-{
+void QueueWidget::enqueue(AnalysisMethod *method) {
     abort_btn->show();
     progressbar->show();
     AnalysisListItem* item = new AnalysisListItem(method);
@@ -76,8 +77,7 @@ void QueueWidget::enqueue(AnalysisMethod *method)
  * @param i
  * Update progressbar progress
  */
-void QueueWidget::update_progress(int i)
-{    
+void QueueWidget::update_progress(int i) {
     progressbar->setValue(i);
 }
 
@@ -85,8 +85,7 @@ void QueueWidget::update_progress(int i)
  * @brief QueueWidget::toggle_show
  * Hide/Show this widget
  */
-void QueueWidget::toggle_show()
-{
+void QueueWidget::toggle_show() {
     if(this->isVisible()) hide();
     else show();
 }

--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -16,9 +16,15 @@ void FrameWidget::toggle_zoom(bool value) {
     }
 }
 
-void FrameWidget::set_analysis_tool()
-{
-    tool = ANALYSIS_BOX;
+void FrameWidget::set_analysis_tool(bool status) {
+    if (status) {
+        tool = ANALYSIS_BOX;
+        setCursor(Qt::CrossCursor);
+    } else {
+        tool = NONE;
+        unsetCursor();
+    }
+
 }
 
 
@@ -265,17 +271,7 @@ void FrameWidget::mouseReleaseEvent(QMouseEvent *event) {
     }
     case ANALYSIS_BOX:
     {
-        AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
-
-        cv::Point end = cv::Point(rect_end.x(), rect_end.y());
-        cv::Point start (rect_start.x(), rect_start.y());
-        cv::Rect scaled = cv::Rect(cv::Point(anchor.x()/m_scale_factor + start.x / m_scale_factor, anchor.y()/m_scale_factor + start.y / m_scale_factor),
-                      cv::Point(anchor.x()/m_scale_factor + end.x / m_scale_factor, anchor.y()/m_scale_factor + end.y / m_scale_factor));        
-        settings->setBounding_box(scaled);
-
-        emit quick_analysis(settings);
-        tool = NONE;
-        mark_rect = false;
+        set_analysis_settings();
         break;
     }
     default:
@@ -304,6 +300,29 @@ void FrameWidget::mouseMoveEvent(QMouseEvent *event) {
         emit mouse_moved(scale_point(event->pos()));
         break;
     }
+}
+
+void FrameWidget::set_analysis_settings() {
+    QMessageBox msg_box;
+    msg_box.setText("Quick analysis");
+    msg_box.setInformativeText("Do you wanna start an analysis on the marked area?");
+    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    int reply = msg_box.exec();
+
+    if (reply != QMessageBox::Yes) return;
+
+    AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
+
+    cv::Point end = cv::Point(rect_end.x(), rect_end.y());
+    cv::Point start (rect_start.x(), rect_start.y());
+    cv::Rect scaled = cv::Rect(cv::Point(anchor.x()/m_scale_factor + start.x / m_scale_factor, anchor.y()/m_scale_factor + start.y / m_scale_factor),
+                  cv::Point(anchor.x()/m_scale_factor + end.x / m_scale_factor, anchor.y()/m_scale_factor + end.y / m_scale_factor));
+    settings->setBounding_box(scaled);
+
+    emit quick_analysis(settings);
+    //tool = NONE;
+    //unsetCursor();
+    mark_rect = false;
 }
 
 void FrameWidget::set_scale_factor(double scale_factor) {

--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -309,19 +309,18 @@ void FrameWidget::set_analysis_settings() {
     msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     int reply = msg_box.exec();
 
-    if (reply != QMessageBox::Yes) return;
+    if (reply == QMessageBox::Yes) {
 
-    AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
+        AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
 
-    cv::Point end = cv::Point(rect_end.x(), rect_end.y());
-    cv::Point start (rect_start.x(), rect_start.y());
-    cv::Rect scaled = cv::Rect(cv::Point(anchor.x()/m_scale_factor + start.x / m_scale_factor, anchor.y()/m_scale_factor + start.y / m_scale_factor),
-                  cv::Point(anchor.x()/m_scale_factor + end.x / m_scale_factor, anchor.y()/m_scale_factor + end.y / m_scale_factor));
-    settings->setBounding_box(scaled);
+        cv::Point end = cv::Point(rect_end.x(), rect_end.y());
+        cv::Point start (rect_start.x(), rect_start.y());
+        cv::Rect scaled = cv::Rect(cv::Point(anchor.x()/m_scale_factor + start.x / m_scale_factor, anchor.y()/m_scale_factor + start.y / m_scale_factor),
+                      cv::Point(anchor.x()/m_scale_factor + end.x / m_scale_factor, anchor.y()/m_scale_factor + end.y / m_scale_factor));
+        settings->setBounding_box(scaled);
 
-    emit quick_analysis(settings);
-    //tool = NONE;
-    //unsetCursor();
+        emit quick_analysis(settings);
+    }
     mark_rect = false;
 }
 

--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -310,7 +310,6 @@ void FrameWidget::set_analysis_settings() {
     int reply = msg_box.exec();
 
     if (reply == QMessageBox::Yes) {
-
         AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
 
         cv::Point end = cv::Point(rect_end.x(), rect_end.y());
@@ -322,6 +321,7 @@ void FrameWidget::set_analysis_settings() {
         emit quick_analysis(settings);
     }
     mark_rect = false;
+    repaint();
 }
 
 void FrameWidget::set_scale_factor(double scale_factor) {

--- a/ViAn/GUI/framewidget.h
+++ b/ViAn/GUI/framewidget.h
@@ -75,7 +75,7 @@ signals:
 public slots:
     void on_new_image(cv::Mat org_image, cv::Mat mod_image, int frame_index);
     void toggle_zoom(bool value);
-    void set_analysis_tool();
+    void set_analysis_tool(bool status);
     void set_scroll_area_size(QSize size);
     void set_analysis(AnalysisProxy *);
     void clear_analysis();
@@ -101,6 +101,7 @@ protected:
 private:
     void init_panning(QPoint pos);
     void set_rect_start(QPoint pos);
+    void set_analysis_settings();
     void panning(QPoint pos);
     void rect_update(QPoint pos);
     void end_panning();

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -28,10 +28,13 @@
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     QDockWidget* project_dock = new QDockWidget(tr("Projects"), this);
     QDockWidget* bookmark_dock = new QDockWidget(tr("Bookmarks"), this);
+    QDockWidget* queue_dock = new QDockWidget(tr("Analysis queue"), this);
     project_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     bookmark_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    queue_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     toggle_project_wgt = project_dock->toggleViewAction();
     toggle_bookmark_wgt = bookmark_dock->toggleViewAction();
+    toggle_queue_wgt = queue_dock->toggleViewAction();
 
     // Initialize video widget
     video_wgt = new VideoWidget();
@@ -56,6 +59,14 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     bookmark_wgt->setWindowFlags(Qt::Window);
     addDockWidget(Qt::RightDockWidgetArea, bookmark_dock);
     bookmark_dock->close();
+    
+    // Initialize analysis queue widget
+    queue_wgt = new QueueWidget();
+    queue_dock->setWidget(queue_wgt);
+    addDockWidget(Qt::LeftDockWidgetArea, queue_dock);
+    queue_dock->setFloating(true);
+    queue_dock->close();
+    analysis_wgt->set_queue_wgt(queue_wgt);
 
     connect(video_wgt, SIGNAL(new_bookmark(VideoProject*,int,cv::Mat)), bookmark_wgt, SLOT(create_bookmark(VideoProject*,int,cv::Mat)));
     connect(project_wgt, SIGNAL(proj_path(std::string)), bookmark_wgt, SLOT(set_path(std::string)));
@@ -282,6 +293,7 @@ void MainWindow::init_view_menu() {
 
     view_menu->addAction(toggle_project_wgt);
     view_menu->addAction(toggle_bookmark_wgt);
+    view_menu->addAction(toggle_queue_wgt);
     view_menu->addSeparator();
     view_menu->addAction(detect_intv_act);
     view_menu->addAction(bound_box_act);
@@ -291,11 +303,12 @@ void MainWindow::init_view_menu() {
 
     toggle_project_wgt->setStatusTip(tr("Show/hide project widget"));
     toggle_bookmark_wgt->setStatusTip(tr("Show/hide bookmark widget"));
+    toggle_queue_wgt->setStatusTip(tr("Show/hide analysis queue widget"));
     detect_intv_act->setStatusTip(tr("Toggle annotations on/off"));
     bound_box_act->setStatusTip(tr("Toggle detections on/off"));
     interval_act->setStatusTip(tr("Toggle interval on/off"));
     drawing_act->setStatusTip(tr("Toggle drawings on/off"));
-    show_analysis_queue->setStatusTip(tr("Show/Hide Analysis queue"));
+    show_analysis_queue->setStatusTip(tr("Show/hide Analysis queue"));
 
     connect(bound_box_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::set_show_detections);
     connect(bound_box_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::update);
@@ -306,7 +319,7 @@ void MainWindow::init_view_menu() {
     connect(drawing_act, &QAction::toggled, video_wgt, &VideoWidget::set_show_overlay);
     // TODO, connect signal back from queue widget to correctly
     // set view checkbox when queuewidget toggle_show triggered from elsewhere
-    connect(show_analysis_queue, &QAction::toggled, analysis_wgt->queue_wgt, &QueueWidget::toggle_show);
+    connect(show_analysis_queue, &QAction::toggled, analysis_wgt->m_queue_wgt, &QueueWidget::toggle_show);
 }
 
 /**

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -28,7 +28,7 @@
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     QDockWidget* project_dock = new QDockWidget(tr("Projects"), this);
     QDockWidget* bookmark_dock = new QDockWidget(tr("Bookmarks"), this);
-    QDockWidget* queue_dock = new QDockWidget(tr("Analysis queue"), this);
+    queue_dock = new QDockWidget(tr("Analysis queue"), this);
     project_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     bookmark_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     queue_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
@@ -49,6 +49,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     // Initialize analysis widget
     analysis_wgt = new AnalysisWidget();
 
+    connect(analysis_wgt, SIGNAL(show_analysis_queue(bool)), this, SLOT(show_analysis_dock(bool)));
     connect(video_wgt, SIGNAL(start_analysis(VideoProject*, AnalysisSettings*)), project_wgt, SLOT(start_analysis(VideoProject*, AnalysisSettings*)));
     connect(video_wgt->frame_wgt, SIGNAL(quick_analysis(AnalysisSettings*)), video_wgt, SLOT(quick_analysis(AnalysisSettings*)));
     connect(project_wgt, SIGNAL(begin_analysis(QTreeWidgetItem*, AnalysisMethod*)),
@@ -580,4 +581,12 @@ void MainWindow::options() {
 void MainWindow::open_project_dialog(){
     QString project_path = QFileDialog().getOpenFileName(this, tr("Open project"), QDir::homePath());
     open_project(project_path);
+}
+
+void MainWindow::show_analysis_dock(bool show) {
+    if (show) {
+        queue_dock->show();
+    } else {
+        queue_dock->close();
+    }
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -313,9 +313,6 @@ void MainWindow::init_view_menu() {
     connect(interval_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::set_show_interval);
     connect(interval_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::update);
     connect(drawing_act, &QAction::toggled, video_wgt, &VideoWidget::set_show_overlay);
-    // TODO, connect signal back from queue widget to correctly
-    // set view checkbox when queuewidget toggle_show triggered from elsewhere
-    //connect(show_analysis_queue, &QAction::toggled, analysis_wgt->m_queue_wgt, &QueueWidget::toggle_show);
 }
 
 /**
@@ -586,7 +583,7 @@ void MainWindow::open_project_dialog(){
 void MainWindow::show_analysis_dock(bool show) {
     if (show) {
         queue_dock->show();
-    } else {
+    } else if (queue_dock->isFloating()) {
         queue_dock->close();
     }
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -303,10 +303,10 @@ void MainWindow::init_view_menu() {
     connect(detect_intv_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::update);
     connect(interval_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::set_show_interval);
     connect(interval_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::update);
+    connect(drawing_act, &QAction::toggled, video_wgt, &VideoWidget::set_show_overlay);
     // TODO, connect signal back from queue widget to correctly
     // set view checkbox when queuewidget toggle_show triggered from elsewhere
     connect(show_analysis_queue, &QAction::toggled, analysis_wgt->queue_wgt, &QueueWidget::toggle_show);
-    //connect(drawing_act, &QAction::toggled, video_wgt->frame_wgt->get_overlay(), &Overlay::set_showing_overlay);
 }
 
 /**

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -277,19 +277,16 @@ void MainWindow::init_view_menu() {
     bound_box_act = new QAction(tr("&Bounding boxes"), this);        //Video oois
     interval_act = new QAction(tr("&Interval"), this);
     drawing_act = new QAction(tr("&Paintings"), this);
-    show_analysis_queue = new QAction(tr("Analysis &Queue"), this);
 
     detect_intv_act->setCheckable(true);
     bound_box_act->setCheckable(true);
     interval_act->setCheckable(true);
     drawing_act->setCheckable(true);
-    show_analysis_queue->setCheckable(true);
 
     detect_intv_act->setChecked(true);
     bound_box_act->setChecked(true);
     interval_act->setChecked(true);
     drawing_act->setChecked(true);
-    show_analysis_queue->setChecked(false);
 
     view_menu->addAction(toggle_project_wgt);
     view_menu->addAction(toggle_bookmark_wgt);
@@ -299,7 +296,6 @@ void MainWindow::init_view_menu() {
     view_menu->addAction(bound_box_act);
     view_menu->addAction(interval_act);
     view_menu->addAction(drawing_act);
-    view_menu->addAction(show_analysis_queue);
 
     toggle_project_wgt->setStatusTip(tr("Show/hide project widget"));
     toggle_bookmark_wgt->setStatusTip(tr("Show/hide bookmark widget"));
@@ -308,7 +304,6 @@ void MainWindow::init_view_menu() {
     bound_box_act->setStatusTip(tr("Toggle detections on/off"));
     interval_act->setStatusTip(tr("Toggle interval on/off"));
     drawing_act->setStatusTip(tr("Toggle drawings on/off"));
-    show_analysis_queue->setStatusTip(tr("Show/hide Analysis queue"));
 
     connect(bound_box_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::set_show_detections);
     connect(bound_box_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::update);
@@ -319,7 +314,7 @@ void MainWindow::init_view_menu() {
     connect(drawing_act, &QAction::toggled, video_wgt, &VideoWidget::set_show_overlay);
     // TODO, connect signal back from queue widget to correctly
     // set view checkbox when queuewidget toggle_show triggered from elsewhere
-    connect(show_analysis_queue, &QAction::toggled, analysis_wgt->m_queue_wgt, &QueueWidget::toggle_show);
+    //connect(show_analysis_queue, &QAction::toggled, analysis_wgt->m_queue_wgt, &QueueWidget::toggle_show);
 }
 
 /**

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -68,12 +68,14 @@ private slots:
 public slots:
     void options(void);
     void open_project_dialog();
+    void show_analysis_dock(bool);
 
 signals:
     void set_status_bar(QString);
     void open_project(QString proj_path);
 
 private:
+    QDockWidget* queue_dock;
 
     VideoWidget* video_wgt;
     ProjectWidget* project_wgt;

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -79,9 +79,11 @@ private:
     ProjectWidget* project_wgt;
     AnalysisWidget* analysis_wgt;
     BookmarkWidget* bookmark_wgt;
+    QueueWidget* queue_wgt;
 
     QAction* toggle_project_wgt;
     QAction* toggle_bookmark_wgt;
+    QAction* toggle_queue_wgt;
 
     AnalysisWindow *analysis_window;
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -77,8 +77,7 @@ int VideoWidget::get_current_video_length(){
     return m_frame_length;
 }
 
-void VideoWidget::quick_analysis(AnalysisSettings * settings)
-{
+void VideoWidget::quick_analysis(AnalysisSettings * settings) {
     if(m_interval.first != -1 && m_interval.second != -1 && (m_interval.first < m_interval.second))
     {
         settings->setInterval(AnalysisInterval(m_interval.first,m_interval.second));
@@ -184,15 +183,14 @@ void VideoWidget::set_btn_icons() {
 
     analysis_btn = new QPushButton(QIcon("../ViAn/Icons/analysis.png"), "", this);
     analysis_play_btn = new QPushButton(QIcon("../ViAn/Icons/play.png"), "", this);
-    tag_btn = new QPushButton(QIcon("../ViAn/Icons/tag.png"), "", this);
-    new_tag_btn = new QPushButton(QIcon("../ViAn/Icons/marker.png"), "", this);
+    new_tag_btn = new QPushButton(QIcon("../ViAn/Icons/tag.png"), "", this);
+    tag_btn = new QPushButton(QIcon("../ViAn/Icons/marker.png"), "", this);
 
 
     zoom_in_btn = new QPushButton(QIcon("../ViAn/Icons/zoom_in.png"), "", this);
     zoom_out_btn = new QPushButton(QIcon("../ViAn/Icons/zoom_out.png"), "", this);
     fit_btn = new QPushButton(QIcon("../ViAn/Icons/fit_screen.png"), "", this);
     original_size_btn = new QPushButton(QIcon("../ViAn/Icons/move.png"), "", this);
-
 
 
     zoom_label = new QLabel;
@@ -202,6 +200,7 @@ void VideoWidget::set_btn_icons() {
     set_end_interval_btn = new QPushButton(QIcon("../ViAn/Icons/end_interval.png"), "", this);
     play_btn->setCheckable(true);
     zoom_in_btn->setCheckable(true);
+    analysis_btn->setCheckable(true);
     analysis_play_btn->setCheckable(true);
 }
 
@@ -222,8 +221,8 @@ void VideoWidget::set_btn_tool_tip() {
 
     bookmark_btn->setToolTip(tr("Bookmark the current frame: Ctrl + B"));
     export_frame_btn->setToolTip("Export current frame: E");
-    tag_btn->setToolTip(tr("Tag the current frame: T"));
     new_tag_btn->setToolTip(tr("Create a new tag: Ctrl + T"));
+    tag_btn->setToolTip(tr("Tag the current frame: T"));
 
     zoom_in_btn->setToolTip(tr("Zoom in: Z"));
     zoom_out_btn->setToolTip(tr("Zoom out"));
@@ -278,11 +277,15 @@ void VideoWidget::set_btn_tab_order() {
     setTabOrder(prev_poi_btn, analysis_btn);
     setTabOrder(analysis_btn, next_poi_btn);
     setTabOrder(next_poi_btn, bookmark_btn);
-    setTabOrder(bookmark_btn, tag_btn);
+    setTabOrder(bookmark_btn, export_frame_btn);
+    setTabOrder(export_frame_btn, new_tag_btn);
+    setTabOrder(new_tag_btn, tag_btn);
     setTabOrder(tag_btn, zoom_in_btn);
     setTabOrder(zoom_in_btn, zoom_out_btn);
     setTabOrder(zoom_out_btn, fit_btn);
     setTabOrder(fit_btn, original_size_btn);
+    setTabOrder(original_size_btn, set_start_interval_btn);
+    setTabOrder(set_start_interval_btn, set_end_interval_btn);
 }
 
 /**
@@ -358,8 +361,8 @@ void VideoWidget::add_btns_to_layouts() {
 
     other_btns->addWidget(bookmark_btn);
     other_btns->addWidget(export_frame_btn);
-    other_btns->addWidget(tag_btn);
     other_btns->addWidget(new_tag_btn);
+    other_btns->addWidget(tag_btn);
 
     control_row->addLayout(other_btns);
 
@@ -396,7 +399,7 @@ void VideoWidget::connect_btns() {
     connect(next_poi_btn, &QPushButton::clicked, this, &VideoWidget::next_poi_btn_clicked);
     connect(prev_poi_btn, &DoubleClickButton::clicked, this, &VideoWidget::prev_poi_btn_clicked);
     connect(prev_poi_btn, &DoubleClickButton::double_clicked, this, &VideoWidget::prev_poi_btn_clicked);
-    connect(analysis_btn, &QPushButton::clicked, frame_wgt, &FrameWidget::set_analysis_tool);
+    connect(analysis_btn, &QPushButton::toggled, frame_wgt, &FrameWidget::set_analysis_tool);
 
     // Tag
     connect(tag_btn, &QPushButton::clicked, this, &VideoWidget::tag_frame);
@@ -1116,6 +1119,7 @@ void VideoWidget::frame_line_edit_finished() {
         emit set_status_bar("Error! Input is negative!");
     } else {
         frame_index.store(converted);
+        on_new_frame();
     }
 }
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -78,8 +78,7 @@ int VideoWidget::get_current_video_length(){
 }
 
 void VideoWidget::quick_analysis(AnalysisSettings * settings) {
-    if(m_interval.first != -1 && m_interval.second != -1 && (m_interval.first < m_interval.second))
-    {
+    if(m_interval.first != -1 && m_interval.second != -1 && (m_interval.first < m_interval.second)) {
         settings->setInterval(AnalysisInterval(m_interval.first,m_interval.second));
         delete_interval();
     }
@@ -926,6 +925,12 @@ void VideoWidget::set_redo() {
 void VideoWidget::set_clear_drawings() {
     update_overlay_settings([&](){
         o_settings.clear_drawings = true;
+    });
+}
+
+void VideoWidget::set_show_overlay(bool show) {
+    update_overlay_settings([&](){
+        o_settings.show_overlay = show;
     });
 }
 

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -147,6 +147,7 @@ public slots:
     void on_playback_stopped(void);
 
     void set_overlay_removed();
+    void set_show_overlay(bool show);
     void set_tool(SHAPES tool);
     void set_tool_text(QString, float);
     void set_color(QColor color);

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -216,6 +216,7 @@ void FrameProcessor::update_manipulator_settings() {
  */
 void FrameProcessor::update_overlay_settings() {
     int curr_frame = m_frame_index->load();
+    m_overlay->set_showing_overlay(m_o_settings->show_overlay);
     m_overlay->set_tool(m_o_settings->tool);
     m_overlay->set_colour(m_o_settings->color);
     m_overlay->set_text_settings(m_o_settings->current_string, m_o_settings->current_font_scale);
@@ -223,11 +224,11 @@ void FrameProcessor::update_overlay_settings() {
     // Undo action
     if (m_o_settings->undo) {
         m_o_settings->undo = false;
-        m_overlay->undo(curr_frame);    
+        m_overlay->undo(curr_frame);
     // Redo action
     } else if (m_o_settings->redo) {
         m_o_settings->redo = false;
-        m_overlay->redo(curr_frame);  
+        m_overlay->redo(curr_frame);
     // Clear drawings action
     } else if (m_o_settings->clear_drawings) {
         m_o_settings->clear_drawings = false;

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -71,7 +71,7 @@ struct overlay_settings {
     bool undo = false;
     bool redo = false;
     bool clear_drawings = false;
-
+    bool show_overlay = true;
     bool overlay_removed = false;
 
     SHAPES tool = NONE;
@@ -79,7 +79,6 @@ struct overlay_settings {
     QString current_string = "Enter text";
     float current_font_scale = 1;
 
-    bool show_overlay = true;
 };
 /**
  * @brief The FrameProcessor class


### PR DESCRIPTION
Queue widget is now a dockable window but otherwise works the same. 

Remove the abort analysis button when no analysis are loaded.
Changed draw-analysis-area cursor to a crosshair.
Made the button toggable and added a "are you sure" pop up after analysis area been drawn. 