### PR TITLE
Panning speed / step size

### DIFF
--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -398,8 +398,25 @@ void FrameWidget::init_panning(QPoint pos) {
  */
 void FrameWidget::panning(QPoint pos) {
     // Using panning
-    QPoint _tmp = prev_pos - pos;
-    emit moved_xy(_tmp.x(), _tmp.y());
+    int dx {prev_pos.x() - pos.x()};
+    int dy {prev_pos.y() - pos.y()};
+
+    panning_tracker.first += dx / m_scale_factor;
+    panning_tracker.second += dy/ m_scale_factor;
+
+    auto scale_panning = [] (double& actual, int& scaled) {
+        if (std::abs(actual) >= 1) {
+            scaled = std::floor(actual);
+            actual -= scaled;
+        }
+    };
+
+    int x{}, y{};
+    scale_panning(panning_tracker.first, x);
+    scale_panning(panning_tracker.second, y);
+
+
+    emit moved_xy(x, y);
     prev_pos = pos;
 }
 

--- a/ViAn/GUI/framewidget.h
+++ b/ViAn/GUI/framewidget.h
@@ -54,6 +54,8 @@ class FrameWidget : public QWidget
     int current_frame_nr = 0;
     double m_scale_factor = 1;
 
+    std::pair<double, double> panning_tracker {}; // Track when to actually pan. Based on current zoom level
+
 public:
     explicit FrameWidget(QWidget *parent = nullptr);
 


### PR DESCRIPTION
Adjusted the panning so that it depends on the current zoom level. The effect of this is that the panning should maintain a normal "speed", event at extrem zoom levels.