### PR TITLE
Finally added remove in the project widget

### DIFF
--- a/ViAn/Analysis/analysismethod.cpp
+++ b/ViAn/Analysis/analysismethod.cpp
@@ -129,7 +129,6 @@ void AnalysisMethod::run() {
     if(*aborted){
         capture.release();
         emit analysis_aborted();
-        emit finito();
         return;
     }else{
         // Makes sure that a POI that stretches to the end of the
@@ -147,7 +146,6 @@ void AnalysisMethod::run() {
         m_analysis.save_saveable(m_save_path);
         AnalysisProxy proxy(m_analysis, m_analysis.full_path());       
         emit finished_analysis(proxy);
-        emit finito();
     }
 }
 

--- a/ViAn/Analysis/analysismethod.h
+++ b/ViAn/Analysis/analysismethod.h
@@ -107,7 +107,6 @@ public slots:
 signals:
     void analysis_aborted();
     void send_progress(int progress);
-    void finito(void);
     void finished_analysis(AnalysisProxy);
 };
 

--- a/ViAn/Analysis/analysismethod.h
+++ b/ViAn/Analysis/analysismethod.h
@@ -22,7 +22,7 @@ using SettingsDescr = std::map<std::string,std::string>;
  * It's implementation is limited to saving rectangles and time intervals for
  * detection.
  */
-class AnalysisMethod : public QObject ,public QRunnable{
+class AnalysisMethod : public QObject, public QRunnable{
     Q_OBJECT    
     Settings m_settings;                // Custom integer settings for constants
     SettingsDescr m_descriptions;       // Descriptions for settings constants

--- a/ViAn/Filehandler/writeable.cpp
+++ b/ViAn/Filehandler/writeable.cpp
@@ -3,3 +3,5 @@
 Writeable::Writeable()
 {
 }
+
+Writeable::~Writeable() {}

--- a/ViAn/Filehandler/writeable.h
+++ b/ViAn/Filehandler/writeable.h
@@ -5,6 +5,8 @@ class Writeable
 {
 public:
     Writeable();
+    virtual ~Writeable();
+
     /**
      * @brief read
      * @param json

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -66,11 +66,13 @@ void AnalysisWidget::perform_analysis(tuple<AnalysisMethod*, QTreeWidgetItem*> a
  * Slot function to be called when an analysis is completed
  * Removes the current analysis from the queue and start the next one if there is one
  */
-void AnalysisWidget::analysis_done(AnalysisProxy analysis) {     
+void AnalysisWidget::analysis_done(AnalysisProxy analysis) {
+    qDebug() << "in done1" << analysis.m_intervals.size();
     emit show_progress(0);
     analysis.m_name = "Analysis";
     current_analysis_item->setText(0,"Analysis");
     analysis_queue.pop_front();
+    qDebug() << "in done2" << analysis.m_intervals.size();
     AnalysisItem* ana_item = dynamic_cast<AnalysisItem*>(current_analysis_item);
     AnalysisProxy* am = new AnalysisProxy(analysis);
     ana_item->set_analysis(am);

--- a/ViAn/GUI/Analysis/tagdialog.cpp
+++ b/ViAn/GUI/Analysis/tagdialog.cpp
@@ -15,12 +15,14 @@ TagDialog::TagDialog(QWidget *parent) : QDialog(parent) {
 
     // Setup widget layout
     QVBoxLayout* vertical_layout = new QVBoxLayout;
+    vertical_layout->deleteLater();
     name = new QLineEdit(this);
     btn_box = new QDialogButtonBox(Qt::Horizontal);
     btn_box->addButton(QDialogButtonBox::Ok);
     btn_box->addButton(QDialogButtonBox::Cancel);
 
     QFormLayout* tag_name_layout = new QFormLayout;
+    tag_name_layout->deleteLater();
     tag_name_layout->addRow("Tag name: ", name);
     vertical_layout->addLayout(tag_name_layout);
     vertical_layout->addWidget(btn_box);
@@ -30,6 +32,12 @@ TagDialog::TagDialog(QWidget *parent) : QDialog(parent) {
     connect(btn_box->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &TagDialog::cancel_btn_clicked);
     setLayout(vertical_layout);
 }
+
+TagDialog::~TagDialog() {
+    delete name;
+    delete btn_box;
+}
+
 /**
  * @brief TagDialog::ok_btn_clicked
  * Send tag name and close widget

--- a/ViAn/GUI/Analysis/tagdialog.h
+++ b/ViAn/GUI/Analysis/tagdialog.h
@@ -20,6 +20,7 @@ class TagDialog : public QDialog
     QDialogButtonBox* btn_box;
 public:
     explicit TagDialog(QWidget *parent = nullptr);
+    ~TagDialog();
 signals:
     // Send tag name
     void tag_name(QString);

--- a/ViAn/GUI/Toolbars/maintoolbar.cpp
+++ b/ViAn/GUI/Toolbars/maintoolbar.cpp
@@ -9,6 +9,13 @@ MainToolbar::MainToolbar() {
     create_buttons();
 }
 
+MainToolbar::~MainToolbar() {
+    delete add_video_act;
+    delete save_act;
+    delete open_act;
+    delete toggle_draw_toolbar_act;
+}
+
 /**
  * @brief MainToolbar::create_actions
  * Creates all actions and sets the drawing toolbar action to be checkable

--- a/ViAn/GUI/Toolbars/maintoolbar.h
+++ b/ViAn/GUI/Toolbars/maintoolbar.h
@@ -10,6 +10,7 @@ class MainToolbar : public QToolBar
     void create_buttons();
 public:
     MainToolbar();
+    ~MainToolbar();
     QAction* add_video_act;
     QAction* save_act;
     QAction* open_act;

--- a/ViAn/GUI/TreeItems/analysisitem.cpp
+++ b/ViAn/GUI/TreeItems/analysisitem.cpp
@@ -21,7 +21,10 @@ AnalysisItem::AnalysisItem() : TreeItem(ANALYSIS_ITEM) {
 /**
  * @brief AnalysisItem::~AnalysisItem
  */
-AnalysisItem::~AnalysisItem() {}
+AnalysisItem::~AnalysisItem() {
+    qDebug() << "analysisitem delete";
+    delete m_analysis;
+}
 
 /**
  * @brief AnalysisItem::set_analysis

--- a/ViAn/GUI/TreeItems/folderitem.cpp
+++ b/ViAn/GUI/TreeItems/folderitem.cpp
@@ -1,9 +1,14 @@
 #include "folderitem.h"
+#include <QDebug>
 
 FolderItem::FolderItem() : TreeItem(FOLDER_ITEM) {
     setFlags(flags() | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled);
     const QIcon folder_icon("../ViAn/Icons/folder.png");
     setIcon(0, folder_icon);
+}
+
+FolderItem::~FolderItem() {
+    qDebug() << "Folder item delete";
 }
 
 void FolderItem::remove() {}

--- a/ViAn/GUI/TreeItems/folderitem.h
+++ b/ViAn/GUI/TreeItems/folderitem.h
@@ -4,6 +4,7 @@
 class FolderItem : public TreeItem {
 public:
     FolderItem();
+    ~FolderItem();
     void remove();
     void rename();
 };

--- a/ViAn/GUI/TreeItems/tagitem.cpp
+++ b/ViAn/GUI/TreeItems/tagitem.cpp
@@ -6,6 +6,11 @@ TagItem::TagItem(Tag *tag) : TreeItem(TAG_ITEM) {
     setIcon(0, folder_icon);
 }
 
+TagItem::~TagItem() {
+    qDebug() << "tag item delete";
+    delete m_tag;
+}
+
 void TagItem::remove(){}
 
 void TagItem::rename() {

--- a/ViAn/GUI/TreeItems/tagitem.h
+++ b/ViAn/GUI/TreeItems/tagitem.h
@@ -9,6 +9,7 @@ public:
     Tag *get_tag();
     void remove();
     void rename();
+    ~TagItem();
 };
 
 #endif // TAGITEM_H

--- a/ViAn/GUI/TreeItems/treeitem.cpp
+++ b/ViAn/GUI/TreeItems/treeitem.cpp
@@ -1,11 +1,11 @@
 #include "treeitem.h"
+#include <QDebug>
 
 TreeItem::TreeItem(int type) : QTreeWidgetItem(type) {
     setFlags(Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
 }
 
-TreeItem::~TreeItem()
-{
-
+TreeItem::~TreeItem() {
+    qDebug() << "Treeitem delete";
 }
 

--- a/ViAn/GUI/TreeItems/videoitem.cpp
+++ b/ViAn/GUI/TreeItems/videoitem.cpp
@@ -12,12 +12,11 @@ VideoItem::VideoItem(): TreeItem(VIDEO_ITEM) {
 }
 
 VideoItem::~VideoItem(){
+    qDebug() << "vid item delete";
     delete m_vid_proj;
 }
 
 void VideoItem::remove(){
-    qDebug() << "Remove VideoItem";
-
 }
 
 void VideoItem::rename(){}

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -14,7 +14,6 @@
 #include "Video/shapes/shape.h"
 #include "Analysis/motiondetection.h"
 #include "Analysis/analysismethod.h"
-#include "Toolbars/maintoolbar.h"
 #include "manipulatordialog.h"
 #include "GUI/frameexporterdialog.h"
 
@@ -84,7 +83,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     init_help_menu();
 
     // Main toolbar
-    MainToolbar* main_toolbar = new MainToolbar();
+    main_toolbar = new MainToolbar();
     main_toolbar->setWindowTitle(tr("Main toolbar"));
     addToolBar(main_toolbar);
     connect(main_toolbar->add_video_act, &QAction::triggered, project_wgt, &ProjectWidget::add_video);
@@ -154,6 +153,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
 
     // Recent projects menu
     RecentProjectDialog* rp_dialog = new RecentProjectDialog(this);
+    rp_dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(rp_dialog, &RecentProjectDialog::open_project, project_wgt, &ProjectWidget::open_project);
     connect(rp_dialog, &RecentProjectDialog::new_project, project_wgt, &ProjectWidget::new_project);
     connect(rp_dialog, &RecentProjectDialog::open_project_from_file, this, &MainWindow::open_project_dialog);
@@ -170,6 +170,9 @@ MainWindow::~MainWindow() {
     delete project_wgt;
     delete analysis_wgt;
     delete bookmark_wgt;
+    delete status_bar;
+    delete draw_toolbar;
+    delete main_toolbar;
 }
 
 /**
@@ -555,6 +558,7 @@ void MainWindow::gen_report() {
 void MainWindow::cont_bri() {
     emit set_status_bar("Opening contrast/brightness settings");
     ManipulatorDialog* man_dialog = new ManipulatorDialog(video_wgt->get_brightness(), video_wgt->get_contrast(), this);
+    man_dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(man_dialog, SIGNAL(values(int,double)), video_wgt, SLOT(update_brightness_contrast(int,double)));
     man_dialog->exec();
 }

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -26,6 +26,7 @@
 #include "Bookmark/bookmarkwidget.h"
 #include "statusbar.h"
 #include "Toolbars/drawingtoolbar.h"
+#include "Toolbars/maintoolbar.h"
 
 using namespace std;
 class AnalysisWindow;
@@ -41,6 +42,7 @@ public:
 
     StatusBar* status_bar;
     DrawingToolbar* draw_toolbar;
+    MainToolbar* main_toolbar;
     QAction* detect_intv_act;
     QAction* bound_box_act;
     QAction* interval_act;

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -818,7 +818,7 @@ void ProjectWidget::remove_project() {
     this->clear();
     delete m_proj;
     m_proj = nullptr;
-    emit remove_overlay();
+    //emit remove_overlay();
     emit project_closed();
     emit remove_overlay();
 }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -104,6 +104,7 @@ void ProjectWidget::add_video() {
         QString vid_name = video_path.right(video_path.length() - index);
         // TODO Check if file is already added
         VideoProject* vid_proj = new VideoProject(new Video(video_path.toStdString()));
+        qDebug() << "added a new one";
         m_proj->add_video_project(vid_proj);
         tree_add_video(vid_proj, vid_name);
     }
@@ -460,7 +461,8 @@ bool ProjectWidget::prompt_save() {
  * @param col
  */
 void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
-    get_index_path(item);
+    Q_UNUSED (col)
+    //get_index_path(item);
     switch(item->type()){
     case VIDEO_ITEM: {
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -168,7 +168,16 @@ void ProjectWidget::set_tree_item_name(QTreeWidgetItem* item, QString name) {
  */
 void ProjectWidget::tree_add_video(VideoProject* vid_proj, const QString& vid_name) {
     VideoItem* vid_item = new VideoItem(vid_proj);
-    insertTopLevelItem(topLevelItemCount(), vid_item);
+
+    // If there only is one selected item and it's a folder,
+    // add the new video to that folder otherwise to the top level
+    QTreeWidgetItem* s_item = (!selectedItems().count()) ? invisibleRootItem() : currentItem();
+    if (s_item->type() == FOLDER_ITEM) {
+        s_item->addChild(vid_item);
+        s_item->setExpanded(true);
+    } else {
+        insertTopLevelItem(topLevelItemCount(), vid_item);
+    }
     vid_proj->set_tree_index(get_index_path(dynamic_cast<QTreeWidgetItem*>(vid_item)));
     emit set_status_bar("Video added: " + vid_name);
     // Add analysis and tag
@@ -562,11 +571,13 @@ void ProjectWidget::context_menu(const QPoint &point) {
         switch (item->type()) {
             case TAG_ITEM:
                 menu.addAction("Rename", this, SLOT(rename_item()));
+                menu.addAction("Remove", this, SLOT(remove_item()));
                 break;
             case ANALYSIS_ITEM:
                 menu.addAction("Rename", this, SLOT(rename_item()));
                 menu.addAction("Show details", this, SLOT(show_details()));
                 menu.addAction("Hide details", this, SLOT(hide_details()));
+                menu.addAction("Remove", this, SLOT(remove_item()));
                 break;
             case FOLDER_ITEM:
                 menu.addAction("Rename", this, SLOT(rename_item()));
@@ -614,26 +625,59 @@ void ProjectWidget::remove_item() {
     QString info_text = "Do you wish to continue?";
     if (message_box(text, info_text, true)) {
         for (auto item : selectedItems()) {
-            if (item->type() == FOLDER_ITEM) {
-                std::vector<VideoItem*> v_items;
-                get_video_items(item, v_items);
-                for (auto v_item : v_items) {
-                    emit item_removed(v_item->get_video_project());
-                }
-            }
-
-            else if (item->type() == VIDEO_ITEM) {
-                VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
-                emit item_removed(vid_item->get_video_project());
-            }
-            // TODO Fix these cases
-//            else if (item->type() == TAG_ITEM || item->type() == ANALYSIS_ITEM) {
-//
-//            }
-            delete item;
+            remove_tree_item(item);
         }
     }
     emit remove_overlay();
+}
+
+/**
+ * @brief ProjectWidget::remove_tree_item
+ * @param item
+ * Recursive function for removing item and all of its children
+ */
+void ProjectWidget::remove_tree_item(QTreeWidgetItem* item) {
+    if (item->type() == FOLDER_ITEM) {
+        while (item->childCount() != 0) {
+            remove_tree_item(item->child(0));
+        }
+    }
+    else if (item->type() == VIDEO_ITEM) {
+        VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
+        VideoProject* v_proj = vid_item->get_video_project();
+
+        // Remove all children
+        while (item->childCount() != 0) {
+            remove_tree_item(item->child(0));
+        }
+        // Remove the video from the list of videos
+        auto it = std::find(m_proj->get_videos().begin(), m_proj->get_videos().end(), v_proj);
+        if (it != m_proj->get_videos().end()) {
+            m_proj->get_videos().erase(it);
+        }
+        emit item_removed(v_proj);
+    }
+    // TODO Add drawing tag
+    else if (item->type() == TAG_ITEM) {
+        emit set_tag_slider(false);
+        emit enable_tag_btn(false);
+
+        VideoItem* vid_item = dynamic_cast<VideoItem*>(item->parent());
+        Tag* tag = dynamic_cast<TagItem*>(item)->get_tag();
+        vid_item->get_video_project()->remove_analysis(tag);
+        emit update_frame();
+    }
+    else if (item->type() == ANALYSIS_ITEM) {
+        emit set_detections(false);
+        emit set_poi_slider(false);
+        emit enable_poi_btns(false, false);
+
+        VideoItem* vid_item = dynamic_cast<VideoItem*>(item->parent());
+        AnalysisProxy* analysis = dynamic_cast<AnalysisItem*>(item)->get_analysis();
+        vid_item->get_video_project()->remove_analysis(analysis);
+        emit update_frame();
+    }
+    delete item;
 }
 
 /**

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -25,10 +25,7 @@ class VideoProject;
 class ProjectWidget : public QTreeWidget
 {
     Q_OBJECT
-    QTreeWidgetItem* clicked_item = nullptr;
-    QPoint* clicked_point = nullptr;
     QTreeWidgetItem* selection_parent = nullptr;
-    bool selecting = false;
     std::set<std::string> allowed_vid_exts {"mkv", "flv", "vob", "ogv", "ogg",
                                 "264", "263", "mjpeg", "avc", "m2ts",
                                 "mts", "avi", "mov", "qt", "wmv", "mp4",

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -72,6 +72,7 @@ public slots:
     bool open_project(QString project_path="");
     bool close_project();
     void remove_project();
+    void remove_tree_item(QTreeWidgetItem*item);
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);
     void advanced_analysis();

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -1,7 +1,8 @@
 #include "recentprojectdialog.h"
+#include <QDebug>
 
 RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::WindowStaysOnTopHint);
+    setWindowFlags(windowFlags() & (~Qt::WindowContextHelpButtonHint | Qt::WindowStaysOnTopHint));
     h_layout = new QHBoxLayout();
     v_main_layout = new QVBoxLayout(this);
     v_btn_layout = new QVBoxLayout();
@@ -36,6 +37,12 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
     connect(new_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_new_btn_clicked);
     connect(browse_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_browse_btn_clicked);
     connect(open_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_open_btn_clicked);
+}
+
+RecentProjectDialog::~RecentProjectDialog() {
+    delete h_layout;
+    recent_list->clear();
+    delete recent_list;
 }
 
 /**

--- a/ViAn/GUI/recentprojectdialog.h
+++ b/ViAn/GUI/recentprojectdialog.h
@@ -28,6 +28,7 @@ class RecentProjectDialog : public QDialog {
     QListWidget* recent_list;
 public:
     RecentProjectDialog(QWidget* parent = nullptr);
+    ~RecentProjectDialog();
 signals:
     void open_project(QString project_path);
     void open_project_from_file(void);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -643,6 +643,7 @@ void VideoWidget::remove_tag_frame() {
  */
 void VideoWidget::new_tag_clicked() {
     TagDialog* tag_dialog = new TagDialog();
+    tag_dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(tag_dialog, SIGNAL(tag_name(QString)), this, SLOT(new_tag(QString)));
     tag_dialog->exec();
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -645,6 +645,7 @@ void VideoWidget::new_tag_clicked() {
     TagDialog* tag_dialog = new TagDialog();
     connect(tag_dialog, SIGNAL(tag_name(QString)), this, SLOT(new_tag(QString)));
     tag_dialog->exec();
+
 }
 
 /**

--- a/ViAn/Project/Analysis/analysis.cpp
+++ b/ViAn/Project/Analysis/analysis.cpp
@@ -1,4 +1,10 @@
 #include "analysis.h"
+#include <QDebug>
+
+Analysis::~Analysis() {
+    qDebug() << "analysis is kill";
+}
+
 /**
  * @brief Analysis::read
  * Reads analysis from json format.

--- a/ViAn/Project/Analysis/analysis.h
+++ b/ViAn/Project/Analysis/analysis.h
@@ -21,6 +21,7 @@ class Analysis : public BasicAnalysis {
 public:
     ANALYSIS_TYPE type;
 public:
+    ~Analysis();
     virtual void read(const QJsonObject& json) override;
     virtual void write(QJsonObject& json) override;
     virtual SAVE_TYPE get_save_type() const override;

--- a/ViAn/Project/Analysis/analysisinterval.cpp
+++ b/ViAn/Project/Analysis/analysisinterval.cpp
@@ -9,7 +9,7 @@ AnalysisInterval::AnalysisInterval(int start, int end) {
 AnalysisInterval::AnalysisInterval() {}
 
 AnalysisInterval::~AnalysisInterval() {
-
+    qDebug() << "analysis interval delete";
 }
 
 /**

--- a/ViAn/Project/Analysis/analysisproxy.cpp
+++ b/ViAn/Project/Analysis/analysisproxy.cpp
@@ -6,12 +6,22 @@
 /**
  * @brief AnalysisMeta::AnalysisMeta
  */
-AnalysisProxy::AnalysisProxy()
-{
-}
+AnalysisProxy::AnalysisProxy() {}
 
 AnalysisProxy::AnalysisProxy(const std::string file_analysis) :
     file_analysis(file_analysis) {
+}
+
+AnalysisProxy::AnalysisProxy(const Analysis &other, const std::string file)
+    : BasicAnalysis(other),
+      file_analysis(file),
+      type(other.type) {
+}
+
+AnalysisProxy::AnalysisProxy(const AnalysisProxy &other) :
+    BasicAnalysis(other),
+    file_analysis(other.file_analysis),
+    type(other.type) {
 }
 
 /**
@@ -19,23 +29,10 @@ AnalysisProxy::AnalysisProxy(const std::string file_analysis) :
  * @return
  */
 Analysis* AnalysisProxy::load_analysis() {
-    Analysis* analysis = new Analysis();    
+    Analysis* analysis = new Analysis();
     analysis->load_saveable(file_analysis);
     m_unsaved_changes = false;
     return analysis;
-}
-AnalysisProxy::AnalysisProxy(const Analysis &other, const std::string file)
-    : BasicAnalysis(other),
-      file_analysis(file),
-      type(other.type) {
-
-}
-
-AnalysisProxy::AnalysisProxy(const AnalysisProxy &other) :
-    BasicAnalysis(other),
-    file_analysis(other.file_analysis),
-    type(other.type)
-{
 }
 
 void AnalysisProxy::reset_root_dir(const std::string &dir)

--- a/ViAn/Project/Analysis/analysisproxy.h
+++ b/ViAn/Project/Analysis/analysisproxy.h
@@ -19,9 +19,10 @@ class AnalysisProxy : public BasicAnalysis
 public:
     AnalysisProxy();
     AnalysisProxy(const std::string file_analysis);
-    Analysis *load_analysis(); // Only use this if all analysisinformation is needed
     AnalysisProxy(const Analysis &other, const std::string file);
     AnalysisProxy(const AnalysisProxy &other);
+
+    Analysis *load_analysis(); // Only use this if all analysisinformation is needed
 
     void reset_root_dir(const std::string& dir);
     virtual ANALYSIS_TYPE get_type() const override;

--- a/ViAn/Project/Analysis/basicanalysis.cpp
+++ b/ViAn/Project/Analysis/basicanalysis.cpp
@@ -15,11 +15,13 @@ BasicAnalysis::BasicAnalysis(const BasicAnalysis &other) :
 
 BasicAnalysis::~BasicAnalysis() {
     qDebug() << "basic analysis delete";
-    qDebug() << m_intervals.size();
-    for (auto it = m_intervals.begin(); it != m_intervals.end(); ++it){
-        m_intervals.erase(it);
-        delete *it;
-    }
+    qDebug() << "size1" << m_intervals.size();
+    m_intervals.clear();
+    qDebug() << "size2" << m_intervals.size();
+//    for (auto it = m_intervals.begin(); it != m_intervals.end(); ++it){
+//        m_intervals.erase(it);
+//        //delete *it;
+//    }
 }
 
 /**

--- a/ViAn/Project/Analysis/basicanalysis.cpp
+++ b/ViAn/Project/Analysis/basicanalysis.cpp
@@ -13,6 +13,15 @@ BasicAnalysis::BasicAnalysis(const BasicAnalysis &other) :
     use_bounding_box(other.use_bounding_box){
 }
 
+BasicAnalysis::~BasicAnalysis() {
+    qDebug() << "basic analysis delete";
+    qDebug() << m_intervals.size();
+    for (auto it = m_intervals.begin(); it != m_intervals.end(); ++it){
+        m_intervals.erase(it);
+        delete *it;
+    }
+}
+
 /**
  * @brief BasicAnalysis::add_POI
  * Adds a POI to the BasicAnalysis.

--- a/ViAn/Project/Analysis/basicanalysis.cpp
+++ b/ViAn/Project/Analysis/basicanalysis.cpp
@@ -66,6 +66,14 @@ void BasicAnalysis::write(QJsonObject &json){
     m_unsaved_changes = false;
 }
 
+ID BasicAnalysis::get_id() {
+    return id;
+}
+
+void BasicAnalysis::set_id(ID new_id) {
+    id = new_id;
+}
+
 std::string BasicAnalysis::get_name() const {
     return m_name;
 }

--- a/ViAn/Project/Analysis/basicanalysis.h
+++ b/ViAn/Project/Analysis/basicanalysis.h
@@ -41,6 +41,7 @@ public:
 
     BasicAnalysis();
     BasicAnalysis(const BasicAnalysis& other);
+    ~BasicAnalysis();
     virtual void read(const QJsonObject& json);
     virtual void write(QJsonObject& json);
     virtual void add_interval(AnalysisInterval *ai);

--- a/ViAn/Project/Analysis/basicanalysis.h
+++ b/ViAn/Project/Analysis/basicanalysis.h
@@ -19,9 +19,11 @@ struct interval_cmp {
     }
 };
 using interval_set = std::set<AnalysisInterval*, interval_cmp>;
+using ID = int;
 class BasicAnalysis : public Saveable
 {       
 public:
+    // TODO Should probably not all be public
     std::string m_name = "2";
     bool m_unsaved_changes = true;
     interval_set m_intervals;
@@ -30,6 +32,8 @@ public:
     bool use_interval = false;
     bool use_bounding_box = false;
 
+private:
+    ID id = 0;
 
 protected:
 
@@ -42,6 +46,9 @@ public:
     virtual void add_interval(AnalysisInterval *ai);
     virtual SAVE_TYPE get_save_type() const;
     virtual ANALYSIS_TYPE get_type() const;
+
+    ID get_id();
+    void set_id(ID id);
 
     std::string get_name() const;
     interval_set get_intervals() const;

--- a/ViAn/Project/Analysis/poi.cpp
+++ b/ViAn/Project/Analysis/poi.cpp
@@ -1,9 +1,14 @@
 #include "poi.h"
+#include <QDebug>
 
 /**
  * @brief POI::POI
  */
 POI::POI(){
+}
+
+POI::~POI() {
+    qDebug() << "poi Delete";
 }
 
 /**

--- a/ViAn/Project/Analysis/poi.h
+++ b/ViAn/Project/Analysis/poi.h
@@ -13,7 +13,8 @@
 class POI : public AnalysisInterval{    
     std::map<int,std::vector<DetectionBox>> OOIs = {};
 public:
-    POI();    
+    POI();
+    ~POI();
     void read(const QJsonObject& json) override;
     void write(QJsonObject& json) override;
 

--- a/ViAn/Project/Test/projecttestsuite.cpp
+++ b/ViAn/Project/Test/projecttestsuite.cpp
@@ -21,6 +21,8 @@ void ProjectTestsuite::add_remove_vid_proj_test(){
     proj->remove_video_project(vp3);
 
     QCOMPARE(proj->m_videos.size() , unsigned(0));
+
+    delete proj;
 }
 
 void ProjectTestsuite::add_remove_report_test(){

--- a/ViAn/Project/Test/videoprojecttest.cpp
+++ b/ViAn/Project/Test/videoprojecttest.cpp
@@ -93,7 +93,7 @@ void VideoProjectTest::read_write_test(){
     VideoProject* vid_proj2 = new VideoProject();
     vid_proj2->read(json_vid_proj);
 
-    QCOMPARE(vid_proj->m_ana_cnt, vid_proj2->m_ana_cnt);
+    QCOMPARE(vid_proj->m_ana_id, vid_proj2->m_ana_id);
     QCOMPARE(vid_proj->m_bm_cnt, vid_proj2->m_bm_cnt);
     QCOMPARE(vid_proj->m_analyses.size(), vid_proj2->m_analyses.size());
     QCOMPARE(vid_proj->m_bookmarks.size(), vid_proj2->m_bookmarks.size());
@@ -123,7 +123,7 @@ void VideoProjectTest::save_load_delete_test(){
     VideoProject* vid_proj2 = new VideoProject();
     vid_proj2->load_saveable(file_path);
 
-    QCOMPARE(vid_proj->m_ana_cnt, vid_proj2->m_ana_cnt);
+    QCOMPARE(vid_proj->m_ana_id, vid_proj2->m_ana_id);
     QCOMPARE(vid_proj->m_bm_cnt, vid_proj2->m_bm_cnt);
     QCOMPARE(vid_proj->m_analyses.size(), vid_proj2->m_analyses.size());
     QCOMPARE(vid_proj->m_bookmarks.size(), vid_proj2->m_bookmarks.size());

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -264,6 +264,8 @@ std::vector<VideoProject*> &Project::get_videos(){
  * @brief Project::get_video
  * @param id
  * @return Returns the video with the specified id.
+ *
+ * TODO Unused
  */
 VideoProject* Project::get_video(const int& v_pos) {
     return m_videos.at(v_pos);

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -48,8 +48,16 @@ Project::Project(const std::string& name, const std::string& dir_path){
  * Clears contents of video map
  */
 Project::~Project(){
+    for (auto video_proj : m_videos) {
+        delete video_proj;
+    }
+
+    for (auto report : m_reports) {
+        //delete report;
+    }
     m_videos.clear();
     m_reports.clear();
+    qDebug() << "delete project";
 }
 
 /**
@@ -72,6 +80,7 @@ ID Project::add_video_project(VideoProject *vid_proj){
 void Project::remove_video_project(VideoProject* vid_proj){
     auto it = std::find(m_videos.begin(), m_videos.end(), vid_proj);
     if (it == m_videos.end()) return;
+    delete *it;
     m_videos.erase(it);
     m_unsaved_changes = true;
 }

--- a/ViAn/Project/video.cpp
+++ b/ViAn/Project/video.cpp
@@ -18,6 +18,10 @@ Video::Video(std::string file_path){
     m_name = file_path.substr(index);
 }
 
+Video::~Video() {
+    qDebug() << "delete video";
+}
+
 std::string Video::get_name() {
     return m_name;
 }

--- a/ViAn/Project/video.h
+++ b/ViAn/Project/video.h
@@ -27,6 +27,7 @@ public:
 public:
     Video();
     Video(std::string file_path);
+    ~Video();
     std::string file_path;
     std::string get_name();
     void read(const QJsonObject& json);

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -68,7 +68,7 @@ bool VideoProject::is_saved() {
 }
 
 /**
- * @brief VideoProject::remove_analysis
+ * @brief VideoProject::delete_analysis
  * @param id of the analysis
  */
 void VideoProject::delete_analysis(const int& id) {
@@ -229,9 +229,11 @@ ID VideoProject::add_analysis(BasicAnalysis *analysis){
 }
 
 void VideoProject::remove_analysis(BasicAnalysis *analysis) {
+    qDebug() << "remove analysis";
     m_analyses.erase(analysis->get_id());
     m_unsaved_changes = true;
-    delete analysis;
+    //delete analysis;
+
 }
 
 /**

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -21,6 +21,7 @@ VideoProject::VideoProject(){
 VideoProject::~VideoProject(){
     delete m_overlay;
     delete video;
+    qDebug() << "delete vid proj";
 }
 
 /**
@@ -252,6 +253,7 @@ void VideoProject::delete_artifacts(){
     m_unsaved_changes = true;
 }
 
+// TODO, not used
 void VideoProject::remove_from_project() {
     m_project->remove_video_project(this);
     m_unsaved_changes = true;

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -222,9 +222,16 @@ void VideoProject::reset_root_dir(const string &dir){
  * Adds analysis to video project.
  */
 ID VideoProject::add_analysis(BasicAnalysis *analysis){
-    m_analyses.insert(std::make_pair(m_ana_cnt, analysis));
+    m_analyses.insert(std::make_pair(m_ana_id, analysis));
+    analysis->set_id(m_ana_id);
     m_unsaved_changes = true;
-    return m_ana_cnt++;
+    return m_ana_id++;
+}
+
+void VideoProject::remove_analysis(BasicAnalysis *analysis) {
+    m_analyses.erase(analysis->get_id());
+    m_unsaved_changes = true;
+    delete analysis;
 }
 
 /**

--- a/ViAn/Project/videoproject.h
+++ b/ViAn/Project/videoproject.h
@@ -30,7 +30,7 @@ class VideoProject : public Saveable{
     Video* video = nullptr;
     Project* m_project = nullptr;
     ID m_bm_cnt = 0;  // Bookmark id counter
-    ID m_ana_cnt = 0; // Analysis id counter
+    ID m_ana_id = 0; // Analysis id counter
 
     bool m_unsaved_changes = true;
 
@@ -48,6 +48,8 @@ public:
 
     ID add_analysis(BasicAnalysis* analysis);
     ID add_bookmark(Bookmark* bookmark);
+
+    void remove_analysis(BasicAnalysis* analysis);
 
     void set_tree_index(std::stack<int> tree_index);
     void set_project(Project* proj);

--- a/ViAn/Project/videoproject.h
+++ b/ViAn/Project/videoproject.h
@@ -61,6 +61,7 @@ public:
     void delete_bookmark(const int& id);
     void delete_artifacts();
 
+    // TODO, not used
     void remove_from_project();
 
     std::string get_index_path();

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -6,6 +6,11 @@
  */
 Overlay::Overlay() {}
 
+Overlay::~Overlay() {
+    // TODO Fix
+    //overlays.clear();
+}
+
 /**
  * @brief Overlay::draw_overlay
  * Draws an overlay on top of the specified frame.

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -43,6 +43,7 @@ public slots:
     void set_tool(SHAPES s);
 public:
     Overlay();
+    ~Overlay();
     bool is_showing_overlay();
     void set_showing_overlay(bool value);
     void draw_overlay(cv::Mat &frame, int frame_nr);


### PR DESCRIPTION
The items in the project widget are now removable. The function iterates recursively and deletes the item and all of its children.
Basic analyses now holds their IDs to make it simple to get them from the list of basic analyses.

Also, when adding a new video to the tree, if a folder is selected the video will now get added in that folder.