### PR TITLE
Quick fix to solve #20. Add video default folder.

### DIFF
--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -96,7 +96,7 @@ void ProjectWidget::add_video() {
     QStringList video_paths = QFileDialog().getOpenFileNames(
                 this,
                 tr("Add video"),
-                m_proj->get_tmp_dir().c_str(),
+                m_proj->get_dir().c_str(),
                 extensions);
 
     for (auto video_path : video_paths){


### PR DESCRIPTION
Fixes #20 
When adding a new video the default folder that's opened is the proj path and not the temp folder.

Getting the correct folder before the project is saved should be fixed in tag-drawing branch.