### PR TITLE
Added modifiers to drawing drawings

### DIFF
--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -387,7 +387,9 @@ void FrameWidget::mouseMoveEvent(QMouseEvent *event) {
         break;
     default:
         if (event->buttons() == Qt::LeftButton || event->buttons() == Qt::RightButton) {
-            emit mouse_moved(scaled_pos);
+            bool shift = (event->modifiers() == Qt::ShiftModifier);
+            bool ctrl = (event->modifiers() == Qt::ControlModifier);
+            emit mouse_moved(scaled_pos, shift, ctrl);
         }
         break;
     }

--- a/ViAn/GUI/framewidget.h
+++ b/ViAn/GUI/framewidget.h
@@ -81,7 +81,7 @@ signals:
 
     void mouse_pressed(QPoint, bool);
     void mouse_released(QPoint, bool);
-    void mouse_moved(QPoint);
+    void mouse_moved(QPoint, bool, bool);
     void mouse_scroll(QPoint);
 public slots:
     void on_new_image(cv::Mat org_image, cv::Mat mod_image, int frame_index);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -464,7 +464,7 @@ bool ProjectWidget::prompt_save() {
  */
 void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
     Q_UNUSED(col)
-    get_index_path(item); //Remove?
+    //get_index_path(item); //Remove?
 
     switch(item->type()){
     case VIDEO_ITEM: {

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -464,8 +464,6 @@ bool ProjectWidget::prompt_save() {
  */
 void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
     Q_UNUSED(col)
-    //get_index_path(item); //Remove?
-
     switch(item->type()){
     case VIDEO_ITEM: {
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -157,7 +157,7 @@ void VideoWidget::init_frame_processor() {
     connect(frame_wgt, &FrameWidget::center_zoom_rect, this, &VideoWidget::center);
     connect(frame_wgt, SIGNAL(mouse_pressed(QPoint, bool)), this, SLOT(mouse_pressed(QPoint, bool)));
     connect(frame_wgt, SIGNAL(mouse_released(QPoint, bool)), this, SLOT(mouse_released(QPoint, bool)));
-    connect(frame_wgt, SIGNAL(mouse_moved(QPoint)), this, SLOT(mouse_moved(QPoint)));
+    connect(frame_wgt, SIGNAL(mouse_moved(QPoint,bool,bool)), this, SLOT(mouse_moved(QPoint,bool,bool)));
     connect(frame_wgt, SIGNAL(mouse_scroll(QPoint)), this, SLOT(mouse_scroll(QPoint)));
     connect(frame_wgt, SIGNAL(send_tool(SHAPES)), this, SLOT(set_tool(SHAPES)));
     connect(frame_wgt, SIGNAL(send_tool_text(QString,float)), this, SLOT(set_tool_text(QString,float)));
@@ -982,9 +982,11 @@ void VideoWidget::mouse_released(QPoint pos, bool right_click) {
     });
 }
 
-void VideoWidget::mouse_moved(QPoint pos) {
+void VideoWidget::mouse_moved(QPoint pos, bool shift, bool ctrl) {
     update_overlay_settings([&](){
         o_settings.mouse_moved = true;
+        o_settings.shift_modifier = shift;
+        o_settings.ctrl_modifier = ctrl;
         o_settings.pos = pos;
     });
 }

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -161,7 +161,7 @@ public slots:
     void set_color(QColor color);
     void mouse_pressed(QPoint pos, bool);
     void mouse_released(QPoint pos, bool right_click);
-    void mouse_moved(QPoint pos);
+    void mouse_moved(QPoint pos, bool shift, bool ctrl);
     void mouse_scroll(QPoint pos);
     void set_current_drawing(Shapes* shape);
     void update_overlay_settings(std::function<void ()> lambda);

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -248,7 +248,7 @@ void FrameProcessor::update_overlay_settings() {
     // Mouse moved action
     } else if (m_o_settings->mouse_moved) {
         m_o_settings->mouse_moved = false;
-        m_overlay->mouse_moved(m_o_settings->pos, curr_frame);
+        m_overlay->mouse_moved(m_o_settings->pos, curr_frame, m_o_settings->shift_modifier, m_o_settings->ctrl_modifier);
     // Mouse scroll wheel action
     } else if (m_o_settings->mouse_scroll) {
         m_o_settings->mouse_scroll = false;

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -71,6 +71,8 @@ struct overlay_settings {
     bool mouse_released = false;
     bool mouse_moved = false;
     bool mouse_scroll = false;
+    bool shift_modifier = false;
+    bool ctrl_modifier = false;
 
     bool update_text = false;
     bool clear_drawings = false;

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -276,7 +276,7 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
         change_tool = false;
         return;
     }
-    update_drawing_position(pos, frame_nr);
+    //update_drawing_position(pos, frame_nr);
     m_right_click = right_click;
 }
 
@@ -287,9 +287,9 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
  * @param pos Mouse coordinates on the frame.
  * @param frame_nr Number of the frame currently shown in the video.
  */
-void Overlay::mouse_moved(QPoint pos, int frame_nr) {
+void Overlay::mouse_moved(QPoint pos, int frame_nr, bool shift, bool ctrl) {
     if (change_tool) return;
-    update_drawing_position(pos, frame_nr);
+    update_drawing_position(pos, frame_nr, shift, ctrl);
 }
 
 /**
@@ -324,7 +324,7 @@ void Overlay::mouse_scroll(QPoint pos, int frame_nr) {
  * @param pos Mouse coordinates on the frame.
  * @param frame_nr Number of the frame currently shown in the video.
  */
-void Overlay::update_drawing_position(QPoint pos, int frame_nr) {
+void Overlay::update_drawing_position(QPoint pos, int frame_nr, bool shift, bool ctrl) {
     if (show_overlay && !overlays[frame_nr].empty()) {
         if (current_shape == HAND) {
             if (current_drawing == nullptr) return;
@@ -351,6 +351,41 @@ void Overlay::update_drawing_position(QPoint pos, int frame_nr) {
             overlays[frame_nr].back()->update_text_pos(pos);
         } else if (current_shape == SELECT) {
         } else {
+            if (current_shape != PEN && shift) {
+                // When the shift modifier is used draw a symmetric drawing
+                // It's not possible with the pen tool.
+                int x = pos.x() - overlays[frame_nr].back()->get_draw_start().x;
+                int y = pos.y() - overlays[frame_nr].back()->get_draw_start().y;
+
+                if (x >= 0 && y >= 0) {
+                    overlays[frame_nr].back()->update_drawing_sym(std::max(x, y), std::max(x, y));
+                } else if (x <= 0 && y <= 0) {
+                    overlays[frame_nr].back()->update_drawing_sym(std::min(x, y), std::min(x, y));
+                } else if (x >= 0 && y <= 0) {
+                    int change = std::max(abs(x), abs(y));
+                    overlays[frame_nr].back()->update_drawing_sym(change, -change);
+                } else if (x <= 0 && y >= 0) {
+                    int change = std::max(abs(x), abs(y));
+                    overlays[frame_nr].back()->update_drawing_sym(-change, change);
+                }
+                m_unsaved_changes = true;
+                return;
+            } else if (ctrl && (current_shape == LINE || current_shape == ARROW)) {
+                int x = pos.x() - overlays[frame_nr].back()->get_draw_start().x;
+                int y = pos.y() - overlays[frame_nr].back()->get_draw_start().y;
+
+                if (x >= abs(y)) {
+                    overlays[frame_nr].back()->update_drawing_sym(x, 0);
+                } else if (-x >= abs(y)) {
+                    overlays[frame_nr].back()->update_drawing_sym(x, 0);
+                } else if (y >= abs(x)) {
+                    overlays[frame_nr].back()->update_drawing_sym(0, y);
+                } else if (-y >= abs(x)) {
+                    overlays[frame_nr].back()->update_drawing_sym(0, y);
+                }
+                m_unsaved_changes = true;
+                return;
+            }
             // The last appended shape is the one we're currently drawing.
             overlays[frame_nr].back()->update_drawing_pos(pos);
         }

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -45,9 +45,9 @@ public:
     int get_current_frame();
     void mouse_pressed(QPoint pos, int frame_nr, bool right_click);
     void mouse_released(QPoint pos, int frame_nr, bool right_click);
-    void mouse_moved(QPoint pos, int frame_nr);
+    void mouse_moved(QPoint pos, int frame_nr, bool shift, bool ctrl);
     void mouse_scroll(QPoint pos, int frame_nr);
-    void update_drawing_position(QPoint pos, int frame_nr);
+    void update_drawing_position(QPoint pos, int frame_nr, bool shift = false, bool ctrl = false);
     void update_text(QString, Shapes*shape);
     void clear(int frame_nr);
     void delete_drawing(Shapes *shape);

--- a/ViAn/Video/shapes/shapes.cpp
+++ b/ViAn/Video/shapes/shapes.cpp
@@ -65,6 +65,10 @@ void Shapes::update_drawing_pos(QPoint pos) {
     draw_end = qpoint_to_point(pos);
 }
 
+void Shapes::update_drawing_sym(int dx, int dy) {
+    draw_end = cv::Point(draw_start.x + dx, draw_start.y + dy);
+}
+
 /**
  * @brief Shape::update_text_pos
  * Updates the start and end point of the text-drawing

--- a/ViAn/Video/shapes/shapes.h
+++ b/ViAn/Video/shapes/shapes.h
@@ -19,6 +19,7 @@ public:
     void set_anchor(QPoint pos);
     void edit_shape(QPoint diff_point);
     void update_drawing_pos(QPoint pos);
+    void update_drawing_sym(int dx, int dy);
     void update_text_pos(QPoint pos);
     void update_text_draw_end();
     virtual void move_shape(QPoint p);


### PR DESCRIPTION
Shift modifier will make sure the drawing is symmetrical. Rects and circles will have equally long sides and lines and arrows will be drawn diagonally.
The control modifier only works for arrow and line. It will make them drawn either horizontally or vetically as a straight line.