### PR TITLE
Interpolation switch

### DIFF
--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -191,6 +191,7 @@ void VideoWidget::set_btn_icons() {
     new_tag_btn = new QPushButton(QIcon("../ViAn/Icons/tag.png"), "", this);
     tag_btn = new QPushButton(QIcon("../ViAn/Icons/marker.png"), "", this);
 
+    interpolate_check = new QCheckBox("Interpolate", this);
     fit_btn = new QPushButton(QIcon("../ViAn/Icons/fit_screen.png"), "", this);
     original_size_btn = new QPushButton(QIcon("../ViAn/Icons/move.png"), "", this);
 
@@ -225,6 +226,8 @@ void VideoWidget::set_btn_tool_tip() {
 
     fit_btn->setToolTip(tr("Scale the video to screen: Ctrl + F"));
     original_size_btn->setToolTip(tr("Reset zoom: Ctrl + R"));
+    interpolate_check->setToolTip("Toggle between bicubic and nearest neighbor interpolation");
+
     set_start_interval_btn->setToolTip("Set left interval point: Shift + Left");
     set_end_interval_btn->setToolTip("Set right interval point: Shift + Right");
 
@@ -256,6 +259,7 @@ void VideoWidget::set_btn_size() {
     analysis_play_btn->setFixedSize(BTN_SIZE);
     enable_poi_btns(false,false);
     tag_btn->setEnabled(false);
+    interpolate_check->setEnabled(false);
 }
 
 /**
@@ -354,7 +358,7 @@ void VideoWidget::add_btns_to_layouts() {
 
     zoom_btns->addWidget(fit_btn);
     zoom_btns->addWidget(original_size_btn);
-
+    zoom_btns->addWidget(interpolate_check);
     zoom_btns->addWidget(zoom_label);
 
     control_row->addLayout(zoom_btns);
@@ -393,6 +397,7 @@ void VideoWidget::connect_btns() {
     connect(frame_wgt, &FrameWidget::trigger_zoom_out, this, &VideoWidget::on_step_zoom);
     connect(fit_btn, &QPushButton::clicked, this, &VideoWidget::on_fit_screen);
     connect(original_size_btn, &QPushButton::clicked, this, &VideoWidget::on_original_size);
+    connect(interpolate_check, &QCheckBox::toggled, this, &VideoWidget::on_interpolate_toggled);
 
     // Other
     connect(bookmark_btn, &QPushButton::clicked, this, &VideoWidget::on_bookmark_clicked);
@@ -463,6 +468,16 @@ void VideoWidget::prev_frame_clicked(){
     } else {
         set_status_bar("Already at the first frame");
     }
+}
+
+/**
+ * @brief VideoWidget::on_interpolate_toggled
+ * Toggles between bicubic (true) or nearest neighbor interpolation (false)
+ * @param checked
+ */
+void VideoWidget::on_interpolate_toggled(bool checked) {
+    int method = cv::INTER_CUBIC ? checked : cv::INTER_NEAREST;
+    set_interpolation_method(method);
 }
 
 /**
@@ -896,6 +911,7 @@ void VideoWidget::set_video_btns(bool b) {
     for (QPushButton* btn : btns) {
         btn->setEnabled(b);
     }
+    interpolate_check->setEnabled(b);
     playback_slider->setEnabled(b);
     frame_line_edit->setEnabled(b);
     speed_slider->setEnabled(b);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1117,6 +1117,17 @@ void VideoWidget::set_draw_area_size(QSize s) {
 }
 
 /**
+ * @brief VideoWidget::set_interpolation_method
+ * Notifies the frame processor that the interpolation method has been changed
+ * @param method - valid opencv interpolation constant
+ */
+void VideoWidget::set_interpolation_method(int method) {
+    update_processing_settings([&](){
+        z_settings.interpolation = method;
+    });
+}
+
+/**
  * @brief VideoWidget::on_zoom_out
  * Tells the frame processor to change the zoom with a constant
  */

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -191,6 +191,7 @@ void VideoWidget::set_btn_icons() {
     new_tag_btn = new QPushButton(QIcon("../ViAn/Icons/tag.png"), "", this);
     tag_btn = new QPushButton(QIcon("../ViAn/Icons/marker.png"), "", this);
 
+    interpolate_check = new QCheckBox("Interpolate", this);
     fit_btn = new QPushButton(QIcon("../ViAn/Icons/fit_screen.png"), "", this);
     original_size_btn = new QPushButton(QIcon("../ViAn/Icons/move.png"), "", this);
 
@@ -225,6 +226,8 @@ void VideoWidget::set_btn_tool_tip() {
 
     fit_btn->setToolTip(tr("Scale the video to screen: Ctrl + F"));
     original_size_btn->setToolTip(tr("Reset zoom: Ctrl + R"));
+    interpolate_check->setToolTip("Toggle between bicubic and nearest neighbor interpolation");
+
     set_start_interval_btn->setToolTip("Set left interval point: Shift + Left");
     set_end_interval_btn->setToolTip("Set right interval point: Shift + Right");
 
@@ -354,7 +357,7 @@ void VideoWidget::add_btns_to_layouts() {
 
     zoom_btns->addWidget(fit_btn);
     zoom_btns->addWidget(original_size_btn);
-
+    zoom_btns->addWidget(interpolate_check);
     zoom_btns->addWidget(zoom_label);
 
     control_row->addLayout(zoom_btns);
@@ -393,6 +396,7 @@ void VideoWidget::connect_btns() {
     connect(frame_wgt, &FrameWidget::trigger_zoom_out, this, &VideoWidget::on_step_zoom);
     connect(fit_btn, &QPushButton::clicked, this, &VideoWidget::on_fit_screen);
     connect(original_size_btn, &QPushButton::clicked, this, &VideoWidget::on_original_size);
+    connect(interpolate_check, &QCheckBox::toggled, this, &VideoWidget::on_interpolate_toggled);
 
     // Other
     connect(bookmark_btn, &QPushButton::clicked, this, &VideoWidget::on_bookmark_clicked);
@@ -463,6 +467,16 @@ void VideoWidget::prev_frame_clicked(){
     } else {
         set_status_bar("Already at the first frame");
     }
+}
+
+/**
+ * @brief VideoWidget::on_interpolate_toggled
+ * Toggles between bicubic (true) or nearest neighbor interpolation (false)
+ * @param checked
+ */
+void VideoWidget::on_interpolate_toggled(bool checked) {
+    int method = cv::INTER_CUBIC ? checked : cv::INTER_NEAREST;
+    set_interpolation_method(method);
 }
 
 /**

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -175,6 +175,7 @@ public slots:
     void center(QPoint, double);
     void set_zoom_rectangle(QPoint p1, QPoint p2);
     void set_draw_area_size(QSize s);
+    void set_interpolation_method(int method);
     void on_step_zoom(double step);
     void set_state(VideoState state);
     void on_fit_screen(void);

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -7,6 +7,7 @@
 #include <QLabel>
 #include <QSize>
 #include <QBoxLayout>
+#include <QCheckBox>
 #include <QPushButton>
 #include <QSlider>
 #include <QShortcut>
@@ -194,6 +195,7 @@ private:
     QLabel* total_time;
     QLineEdit* frame_line_edit;
     QLabel* zoom_label;
+    QCheckBox* interpolate_check; // Checked = bicubic, unchecked = nearest
 
     QShortcut* remove_frame_act;
 
@@ -213,6 +215,7 @@ private:
     QPushButton* set_start_interval_btn;
     QPushButton* set_end_interval_btn;
     QPushButton* export_frame_btn;
+
     //Layouts
     QHBoxLayout* control_row;     // Container for all button areas
     QHBoxLayout* video_btns;      // Play, pause etc
@@ -255,6 +258,8 @@ private slots:
     void stop_btn_clicked(void);
     void next_frame_clicked(void);
     void prev_frame_clicked(void);
+
+    void on_interpolate_toggled(bool checked);
 };
 
 #endif // VIDEOWIDGET_H

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -181,6 +181,10 @@ void FrameProcessor::update_zoomer_settings() {
         m_z_settings->original = false;
         m_zoomer.reset();
     }
+    // Set interpolation method
+    else if (m_zoomer.get_interpolation_method() != m_z_settings->interpolation){
+        m_zoomer.set_interpolation_method(m_z_settings->interpolation);
+    }
 
     // Store changes made
     m_z_settings->zoom_factor = m_zoomer.get_scale_factor();

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -37,6 +37,8 @@ struct zoomer_settings {
     double zoom_factor = 1;
     double zoom_step = 1;
 
+    int interpolation = cv::INTER_NEAREST;
+
     // Panning
     int x_movement = 0;
     int y_movement = 0;

--- a/ViAn/Video/zoomer.cpp
+++ b/ViAn/Video/zoomer.cpp
@@ -58,6 +58,15 @@ void Zoomer::set_viewport_size(const QSize size) {
 }
 
 /**
+ * @brief Zoomer::set_interpolation_method
+ * Sets the interpolation method to be used
+ * @param method
+ */
+void Zoomer::set_interpolation_method(const int &method) {
+    m_interpol_method = method;
+}
+
+/**
  * @brief Zoomer::move_zoom_rect
  * Updates the position of the zoom rectangle relative to the frame
  * @param x movement on the x-axis
@@ -153,6 +162,14 @@ void Zoomer::update_scale() {
 
 QSize Zoomer::get_viewport_size() const {
     return m_viewport_size;
+}
+
+/**
+ * @brief Zoomer::get_interpolation_method
+ * @return current interpolation method
+ */
+int Zoomer::get_interpolation_method() const {
+    return m_interpol_method;
 }
 
 /**

--- a/ViAn/Video/zoomer.h
+++ b/ViAn/Video/zoomer.h
@@ -27,6 +27,7 @@ public:
     void set_zoom_rect(QPoint p1, QPoint p2);
     void set_frame_size(cv::Size frame_size);
     void set_viewport_size(const QSize size);
+    void set_interpolation_method(const int& method);
     void move_zoom_rect(int x, int y);
     void center_zoom_rect(QPoint, double zoom_step);
     void set_state(QPoint anchor, double scale_factor);
@@ -41,6 +42,7 @@ public:
 
     QPoint get_anchor() const;
     QSize get_viewport_size() const;
+    int get_interpolation_method() const;
 
     void update_rect_size();
 private:


### PR DESCRIPTION
Added a checkbox that toggles between bicubic (checked) and nearest neighbor (unchecked) interpolation.
The setting is only applied when the zoom level is above 100%, at lower leves bilinear is used (As before).