### PR TITLE
Recent project dialog shows last saved on the projects

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -10,7 +10,6 @@
 #include <QDebug>
 #include <QProgressDialog>
 #include <QTemporaryDir>
-#include <chrono>
 #include <thread>
 #include "Video/shapes/shapes.h"
 #include "Analysis/motiondetection.h"

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1085,7 +1085,7 @@ bool ProjectWidget::save_project() {
 
     RecentProject rp;
     rp.load_recent();
-    rp.update_recent(m_proj->get_name(), m_proj->get_file());
+    rp.update_recent(m_proj->get_name(), m_proj->get_file(), m_proj->get_last_changed());
     set_status_bar("Project saved");
     return true;
 }

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -1,4 +1,5 @@
 #include <QFileDialog>
+#include <QHeaderView>
 #include "recentprojectdialog.h"
 #include <QDebug>
 
@@ -14,7 +15,12 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
     v_main_layout->addWidget(new QLabel(tr("Recent projects:"))); // First row
     v_main_layout->addLayout(h_layout);
 
-    recent_list = new QListWidget();
+    recent_list = new QTreeWidget();
+    recent_list->setColumnCount(2);
+    recent_list->headerItem()->setText(0, "Project");
+    recent_list->headerItem()->setText(1, "Last changed");
+    recent_list->setRootIsDecorated(false);                     // Remove the empty space to the left of the item
+
     h_layout->addWidget(recent_list);                           // Second row first col
     h_layout->addLayout(v_btn_layout);                          // Second row second col
 
@@ -30,12 +36,14 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
     v_btn_layout->addWidget(open_btn);                          // Second row second col third row
 
     for (auto project : RecentProject().load_recent()) {
-        QListWidgetItem* item = new QListWidgetItem(QString::fromStdString(std::get<0>(project)));
-        item->setToolTip(QString::fromStdString(std::get<1>(project)));
-        recent_list->addItem(item);
+        QTreeWidgetItem* item = new QTreeWidgetItem(recent_list);
+        item->setText(0, QString::fromStdString(std::get<0>(project)));     // Set name
+        item->setText(1, QString::fromStdString(std::get<2>(project)));     // Set the last changed date
+        item->setToolTip(0, QString::fromStdString(std::get<1>(project)));
+        recent_list->addTopLevelItem(item);
     }
 
-    connect(recent_list, &QListWidget::itemDoubleClicked, this, &RecentProjectDialog::on_item_double_clicked);
+    connect(recent_list, &QTreeWidget::itemDoubleClicked, this, &RecentProjectDialog::on_item_double_clicked);
     connect(new_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_new_btn_clicked);
     connect(browse_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_browse_btn_clicked);
     connect(open_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_open_btn_clicked);
@@ -52,9 +60,9 @@ RecentProjectDialog::~RecentProjectDialog() {
  * Accepts dialog and emits signal to open the clicked project
  * @param item
  */
-void RecentProjectDialog::on_item_double_clicked(QListWidgetItem* item) {
+void RecentProjectDialog::on_item_double_clicked(QTreeWidgetItem* item) {
     accept();
-    emit open_project(item->toolTip());
+    emit open_project(item->toolTip(0));
 }
 
 /**
@@ -85,6 +93,6 @@ void RecentProjectDialog::on_browse_btn_clicked(){
 
 void RecentProjectDialog::on_open_btn_clicked() {
     if (recent_list->selectedItems().length() == 0) return;
-    open_project(recent_list->currentItem()->toolTip());
+    open_project(recent_list->currentItem()->toolTip(0));
     accept();
 }

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -16,7 +16,7 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
     v_main_layout->addLayout(h_layout);
 
     recent_list = new QTreeWidget();
-    recent_list->setColumnCount(2);
+    recent_list->setColumnCount(NUM_COLUMNS);
     recent_list->headerItem()->setText(0, "Project");
     recent_list->headerItem()->setText(1, "Last changed");
     recent_list->setRootIsDecorated(false);                     // Remove the empty space to the left of the item

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -30,8 +30,8 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
     v_btn_layout->addWidget(open_btn);                          // Second row second col third row
 
     for (auto project : RecentProject().load_recent()) {
-        QListWidgetItem* item = new QListWidgetItem(QString::fromStdString(project.first));
-        item->setToolTip(QString::fromStdString(project.second));
+        QListWidgetItem* item = new QListWidgetItem(QString::fromStdString(std::get<0>(project)));
+        item->setToolTip(QString::fromStdString(std::get<1>(project)));
         recent_list->addItem(item);
     }
 

--- a/ViAn/GUI/recentprojectdialog.h
+++ b/ViAn/GUI/recentprojectdialog.h
@@ -26,6 +26,8 @@ class RecentProjectDialog : public QDialog {
     QPushButton* browse_btn;
     QPushButton* open_btn;
     QTreeWidget* recent_list;
+
+    const int NUM_COLUMNS = 2;
 public:
     RecentProjectDialog(QWidget* parent = nullptr);
     ~RecentProjectDialog();

--- a/ViAn/GUI/recentprojectdialog.h
+++ b/ViAn/GUI/recentprojectdialog.h
@@ -6,8 +6,8 @@
 #include <QObject>
 #include <QBoxLayout>
 #include <QPushButton>
-#include <QListWidget>
-#include <QListWidgetItem>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
 #include <QLabel>
 
 #include "Project/recentproject.h"
@@ -25,7 +25,7 @@ class RecentProjectDialog : public QDialog {
     QPushButton* new_btn;
     QPushButton* browse_btn;
     QPushButton* open_btn;
-    QListWidget* recent_list;
+    QTreeWidget* recent_list;
 public:
     RecentProjectDialog(QWidget* parent = nullptr);
     ~RecentProjectDialog();
@@ -34,7 +34,7 @@ signals:
     void open_project_from_file(QString);
     void new_project(void);
 private slots:
-    void on_item_double_clicked(QListWidgetItem* item);
+    void on_item_double_clicked(QTreeWidgetItem *item);
     void on_new_btn_clicked();
     void on_browse_btn_clicked();
     void on_open_btn_clicked();

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -1,4 +1,6 @@
 #include "project.h"
+#include <chrono>
+#include <ctime>
 #include <QDebug>
 
 /**
@@ -214,6 +216,10 @@ bool Project::save_project(){
     QDir directory;
     directory.mkpath(QString::fromStdString(m_dir));
     directory.mkpath(QString::fromStdString(m_dir_bookmarks));
+    auto time = std::chrono::system_clock::now();
+    std::time_t now_c = std::chrono::system_clock::to_time_t(time);
+    last_changed = std::ctime(&now_c);
+    std::cout << last_changed << std::endl;
     return save_saveable(m_file);
 }
 
@@ -326,6 +332,10 @@ std::string Project::get_name() const {
 
 std::string Project::get_file() const {
     return m_file;
+}
+
+std::string Project::get_last_changed() const {
+    return last_changed;
 }
 
 void Project::set_name(std::string name) {

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -1,6 +1,7 @@
 #include "project.h"
 #include <chrono>
 #include <ctime>
+#include <string>
 #include <QDebug>
 
 /**
@@ -219,6 +220,7 @@ bool Project::save_project(){
     auto time = std::chrono::system_clock::now();
     std::time_t now_c = std::chrono::system_clock::to_time_t(time);
     last_changed = std::ctime(&now_c);
+    last_changed.erase(last_changed.end()-1);       // Remove the "\n"
     std::cout << last_changed << std::endl;
     return save_saveable(m_file);
 }

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -221,7 +221,6 @@ bool Project::save_project(){
     std::time_t now_c = std::chrono::system_clock::to_time_t(time);
     last_changed = std::ctime(&now_c);
     last_changed.erase(last_changed.end()-1);       // Remove the "\n"
-    std::cout << last_changed << std::endl;
     return save_saveable(m_file);
 }
 

--- a/ViAn/Project/project.h
+++ b/ViAn/Project/project.h
@@ -37,6 +37,7 @@ class Project : public Saveable{
     std::string m_name = "";            // Simply the project name
     std::string m_dir_bookmarks = "";   // Project directory + /Bookmarks
     std::string m_file = "";            // Full path to the project file: project path + project name + .vian
+    std::string last_changed = "";      // Date and time when the project was last saved
 
     std::vector<VideoProject*> m_videos;
     std::map<ID, Report*> m_reports;
@@ -80,6 +81,7 @@ public:
     std::string get_dir() const;
     std::string get_name() const;
     std::string get_file() const;
+    std::string get_last_changed() const;
     void set_name(std::string);
     void set_dir(std::string);
     void set_file(std::string);

--- a/ViAn/Project/recentproject.cpp
+++ b/ViAn/Project/recentproject.cpp
@@ -11,10 +11,15 @@ RecentProject::RecentProject(){}
  * @param name  :   project name
  * @param project_path  : path to the project
  */
-void RecentProject::update_recent(const std::string& name, const std::string &project_path) {
-    std::pair<std::string, std::string> new_proj = std::make_pair(name, project_path);
-    auto item = std::find(recent_items.begin(), recent_items.end(), new_proj);
-    if (item != recent_items.end()) recent_items.erase(item);
+void RecentProject::update_recent(const std::string& name, const std::string &project_path, const std::string &last_changed) {
+    std::tuple<std::string, std::string, std::string> new_proj = std::make_tuple(name, project_path, last_changed);
+
+    for (auto item : recent_items) {
+        if (std::get<1>(item) == std::get<1>(new_proj)) {
+            //auto item_it = recent_items.find
+            recent_items.remove(item);
+        }
+    }
     if (recent_items.size() >= RECENT_MAX) recent_items.resize(RECENT_MAX);
     recent_items.push_front(new_proj);
     QDir().mkpath(QString::fromStdString(PATH));
@@ -26,7 +31,7 @@ void RecentProject::update_recent(const std::string& name, const std::string &pr
  * Reads and returns recent projects
  * @return
  */
-std::list<std::pair<std::string, std::string>> RecentProject::load_recent(){
+std::list<std::tuple<std::string, std::string, std::string> > RecentProject::load_recent(){
     load_saveable(PATH + FILE_NAME);
     return recent_items;
 }
@@ -37,10 +42,13 @@ std::list<std::pair<std::string, std::string>> RecentProject::load_recent(){
  */
 void RecentProject::read(const QJsonObject &json) {
     for (auto j : json["recent"].toArray()) {
-        QJsonObject pair = j.toObject();
-        QString key = pair.keys()[0];  //  Is always of length 1
-        if(QFile(pair.value(key).toString()).exists())
-            recent_items.push_back(std::make_pair(key.toStdString(), pair.value(key).toString().toStdString()));
+        QJsonObject tuple = j.toObject();
+        std::string name = tuple["name"].toString().toStdString();
+        std::string path = tuple["path"].toString().toStdString();
+        std::string last_changed = tuple["last changed"].toString().toStdString();
+        if (QFile(QString::fromStdString(path)).exists()) {
+            recent_items.push_back(std::make_tuple(name, path, last_changed));
+        }
     }
 }
 
@@ -51,9 +59,11 @@ void RecentProject::read(const QJsonObject &json) {
 void RecentProject::write(QJsonObject &json) {
     QJsonArray j_array;
     for (auto p : recent_items){
-        QJsonObject pair;
-        pair[QString::fromStdString(p.first)] = QString::fromStdString(p.second);
-        j_array.append(pair);
+        QJsonObject tuple;
+        tuple["name"] = QString::fromStdString(std::get<0>(p));
+        tuple["path"] = QString::fromStdString(std::get<1>(p));
+        tuple["last changed"] = QString::fromStdString(std::get<2>(p));
+        j_array.append(tuple);
     }
     json["recent"] = j_array;
 }

--- a/ViAn/Project/recentproject.cpp
+++ b/ViAn/Project/recentproject.cpp
@@ -16,7 +16,6 @@ void RecentProject::update_recent(const std::string& name, const std::string &pr
 
     for (auto item : recent_items) {
         if (std::get<1>(item) == std::get<1>(new_proj)) {
-            //auto item_it = recent_items.find
             recent_items.remove(item);
         }
     }

--- a/ViAn/Project/recentproject.h
+++ b/ViAn/Project/recentproject.h
@@ -9,15 +9,15 @@
 #include "Filehandler/saveable.h"
 
 class RecentProject : public Saveable {
-    std::list<std::pair<std::string, std::string>> recent_items;
+    std::list<std::tuple<std::string, std::string, std::string>> recent_items;
     static const std::string FILE_NAME;
     static const std::string PATH;
     static const int RECENT_MAX = 10;
 public:
     RecentProject();
 
-    void update_recent(const std::string& name, const std::string& project_path);
-    std::list<std::pair<std::string, std::string>> load_recent();
+    void update_recent(const std::string& name, const std::string& project_path, const std::string& last_changed);
+    std::list<std::tuple<std::string, std::string, std::string>> load_recent();
 
     void read(const QJsonObject& json);
     void write(QJsonObject& json);

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -2,6 +2,7 @@
 #include <QThread>
 #include <QDebug>
 #include <QTime>
+#include <chrono>
 
 VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_playing,
                          std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,


### PR DESCRIPTION
The project's last saved date and time is saved in the recent project file and shown in the recent project dialog. 

QListWidget is changed to QTreeWidget to get multiple columns.
Might not be backwards compatible so it wont show old recent projects.