### PR TITLE
Frame rate

### DIFF
--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -335,9 +335,9 @@ void VideoWidget::init_speed_slider() {
     speed_slider->setTickPosition(QSlider::TicksBelow);
     speed_slider->setEnabled(false);
     speed_slider->setToolTip(tr("Adjust playback speed"));
-    QLabel *label1 = new QLabel("1/16x", this);
+    QLabel *label1 = new QLabel("1/8x", this);
     QLabel *label2 = new QLabel("1x", this);
-    QLabel *label3 = new QLabel("16x", this);
+    QLabel *label3 = new QLabel("8x", this);
     QFont f("Helvetica", 6, QFont::Normal);
     label1->setFont(f);
     label2->setFont(f);
@@ -1284,8 +1284,14 @@ void VideoWidget::update_processing_settings(std::function<void ()> lambda) {
 }
 
 void VideoWidget::update_playback_speed(int speed) {
-    qDebug() << speed;
     m_speed_step.store(speed);
+    if (speed > 0) {
+        fps_label->setText("Fps: " + QString::number(m_frame_rate*speed*2));
+    } else if (speed < 0) {
+        fps_label->setText("Fps: " + QString::number(m_frame_rate/std::abs(speed*2)));
+    } else {
+        fps_label->setText("Fps: " + QString::number(m_frame_rate));
+    }
 }
 
 void VideoWidget::set_current_frame_size(QSize size) {

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -204,8 +204,10 @@ void VideoWidget::set_btn_icons() {
     zoom_label->setMaximumWidth(60);
     zoom_label->setEnabled(false);
     connect(zoom_label, &QLineEdit::editingFinished, this, &VideoWidget::zoom_label_finished);
+    fps_label = new QLabel("Fps: 0", this);
     set_start_interval_btn = new QPushButton(QIcon("../ViAn/Icons/start_interval.png"), "", this);
     set_end_interval_btn = new QPushButton(QIcon("../ViAn/Icons/end_interval.png"), "", this);
+
     play_btn->setCheckable(true);
     analysis_play_btn->setCheckable(true);
 }
@@ -233,8 +235,9 @@ void VideoWidget::set_btn_tool_tip() {
     original_size_btn->setToolTip(tr("Reset zoom: Ctrl + H"));
     interpolate_check->setToolTip("Toggle between bicubic and nearest neighbor interpolation");
 
-    set_start_interval_btn->setToolTip("Set left interval point: Shift + Left");
-    set_end_interval_btn->setToolTip("Set right interval point: Shift + Right");
+    fps_label->setToolTip("The frame rate of the video");
+    set_start_interval_btn->setToolTip("Set left interval point: I");
+    set_end_interval_btn->setToolTip("Set right interval point: O");
 }
 
 /**
@@ -386,6 +389,7 @@ void VideoWidget::add_btns_to_layouts() {
 
     control_row->addLayout(zoom_btns);
 
+    interval_btns->addWidget(fps_label);
     interval_btns->addWidget(set_start_interval_btn);
     interval_btns->addWidget(set_end_interval_btn);
 
@@ -436,6 +440,7 @@ void VideoWidget::init_playback_slider() {
     QHBoxLayout* progress_area = new QHBoxLayout();
     current_time = new QLabel("--:--");
     total_time = new QLabel("--:--");
+    max_frames = new QLabel("0", this);
     frame_line_edit = new QLineEdit("0", this);
 
     frame_line_edit->setFixedWidth(50);
@@ -451,6 +456,7 @@ void VideoWidget::init_playback_slider() {
     progress_area->addWidget(playback_slider);
     progress_area->addWidget(total_time);
     progress_area->addWidget(frame_line_edit);
+    progress_area->addWidget(max_frames);
     vertical_layout->addLayout(progress_area);
 
     connect(playback_slider, &QSlider::sliderPressed, this, &VideoWidget::on_playback_slider_pressed);
@@ -993,6 +999,8 @@ void VideoWidget::on_video_info(int video_width, int video_height, int frame_rat
     playback_slider->setMaximum(last_frame);
     set_total_time((last_frame + 1) / frame_rate);
     set_current_time(frame_index.load() / m_frame_rate);
+    fps_label->setText("Fps: " + QString::number(m_frame_rate));
+    max_frames->setText("/ " + QString::number(last_frame));
 }
 
 void VideoWidget::on_playback_stopped(){
@@ -1275,7 +1283,8 @@ void VideoWidget::update_processing_settings(std::function<void ()> lambda) {
     v_sync.con_var.notify_all();
 }
 
-void VideoWidget::update_playback_speed(int speed){
+void VideoWidget::update_playback_speed(int speed) {
+    qDebug() << speed;
     m_speed_step.store(speed);
 }
 

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -190,9 +190,11 @@ private:
     QSlider* speed_slider;
     QLabel* current_time;
     QLabel* total_time;
+    QLabel* max_frames;
     QLineEdit* frame_line_edit;
     QLineEdit* zoom_label;
     QCheckBox* interpolate_check; // Checked = bicubic, unchecked = nearest
+    QLabel* fps_label;
 
     //Buttons
     QPushButton* play_btn;

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QTime>
 #include <chrono>
+#include <cmath>
 
 VideoPlayer::VideoPlayer(std::atomic<int>* frame_index, std::atomic_bool *is_playing,
                          std::atomic_bool* new_frame, std::atomic_int* width, std::atomic_int* height,
@@ -56,7 +57,6 @@ void VideoPlayer::load_video(){
  * @param speed_steps   :   Steps to increase/decrease
  */
 void VideoPlayer::set_playback_speed(int speed_steps) {
-    //qDebug() << speed_steps;
     if (speed_steps > 0) {
         speed_multiplier = 1.0 / (speed_steps * 2);
     } else if (speed_steps < 0) {
@@ -64,7 +64,7 @@ void VideoPlayer::set_playback_speed(int speed_steps) {
     } else {
         speed_multiplier = 1;
     }
-    //qDebug() << speed_multiplier;
+    m_cur_speed_step = speed_steps;
 }
 
 /**
@@ -113,7 +113,6 @@ void VideoPlayer::check_events() {
                 display_index();
                 std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
                 elapsed = end - start;
-
             }
         }
         lk.unlock();

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -56,6 +56,7 @@ void VideoPlayer::load_video(){
  * @param speed_steps   :   Steps to increase/decrease
  */
 void VideoPlayer::set_playback_speed(int speed_steps) {
+    //qDebug() << speed_steps;
     if (speed_steps > 0) {
         speed_multiplier = 1.0 / (speed_steps * 2);
     } else if (speed_steps < 0) {
@@ -63,6 +64,7 @@ void VideoPlayer::set_playback_speed(int speed_steps) {
     } else {
         speed_multiplier = 1;
     }
+    //qDebug() << speed_multiplier;
 }
 
 /**

--- a/ViAn/Video/videoplayer.h
+++ b/ViAn/Video/videoplayer.h
@@ -55,7 +55,7 @@ class VideoPlayer : public QObject{
     // Player state
     std::atomic_bool* m_is_playing;
     bool m_playback_status = false;
-    int m_cur_speed_step = 1;
+    int m_cur_speed_step = 0;
     double speed_multiplier = 1;
     int current_frame = -1;
 


### PR DESCRIPTION
Added the number of frames of the video and the fps as two labels. The fps label is changes when the speed slider is changed and the speed slider is fixed to work as intended. Before it didn't correctly raise the speed on the first tic or update the m_cur_speed_step in video player.