### PR TITLE
Prevent crash when closing project while analysis is running

### DIFF
--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -102,11 +102,11 @@ void AnalysisWidget::abort_all_analysis() {
 void AnalysisWidget::on_analysis_aborted() {
     analysis_queue.pop_front();
     delete current_analysis_item; // Delete item from tree
-    auto it = abort_map.find(current_method);   
+    auto it = abort_map.find(current_method);
     abort_map.erase(it);
 
     m_queue_wgt->next();
-    if (!analysis_queue.empty()) {        
+    if (!analysis_queue.empty()) {
         current_analysis_item = std::get<1>(analysis_queue.front());
         move_queue();
         perform_analysis(analysis_queue.front());

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -94,6 +94,11 @@ void AnalysisWidget::abort_analysis() {
     *abort = true;
 }
 
+void AnalysisWidget::abort_all_analysis() {
+    abort_all = true;
+    abort_analysis();
+}
+
 void AnalysisWidget::on_analysis_aborted() {
     analysis_queue.pop_front();
     delete current_analysis_item; // Delete item from tree
@@ -105,6 +110,9 @@ void AnalysisWidget::on_analysis_aborted() {
         current_analysis_item = std::get<1>(analysis_queue.front());
         move_queue();
         perform_analysis(analysis_queue.front());
+        if (abort_all) {
+            abort_analysis();
+        }
         return;
     }
     // Queue Empty

--- a/ViAn/GUI/Analysis/analysiswidget.cpp
+++ b/ViAn/GUI/Analysis/analysiswidget.cpp
@@ -103,7 +103,7 @@ void AnalysisWidget::on_analysis_aborted() {
     analysis_queue.pop_front();
     delete current_analysis_item; // Delete item from tree
     auto it = abort_map.find(current_method);
-    abort_map.erase(it);
+    if (it != abort_map.end()) abort_map.erase(it);
 
     m_queue_wgt->next();
     if (!analysis_queue.empty()) {

--- a/ViAn/GUI/Analysis/analysiswidget.h
+++ b/ViAn/GUI/Analysis/analysiswidget.h
@@ -30,6 +30,7 @@ class AnalysisWidget : public QWidget
     std::clock_t start;
     int duration = 0;
     int duplicate_save_file_inc = 1;
+    bool abort_all = false;
 public:
     explicit AnalysisWidget(QWidget *parent = nullptr);
 
@@ -66,6 +67,9 @@ public slots:
 
     // Answer request for aborting analysis
     void abort_analysis();
+
+    // Answer request for aborting all analysis
+    void abort_all_analysis();
 
     // Analysis finished aborting
     void on_analysis_aborted();

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -60,6 +60,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(video_wgt->frame_wgt, SIGNAL(quick_analysis(AnalysisSettings*)), video_wgt, SLOT(quick_analysis(AnalysisSettings*)));
     connect(project_wgt, SIGNAL(begin_analysis(QTreeWidgetItem*, AnalysisMethod*)),
             analysis_wgt, SLOT(start_analysis(QTreeWidgetItem*, AnalysisMethod*)));
+    connect(project_wgt, &ProjectWidget::abort_all_analysis, analysis_wgt, &AnalysisWidget::abort_all_analysis);
 
     // Initialize bookmark widget
     bookmark_wgt = new BookmarkWidget();

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -125,6 +125,7 @@ private:
     std::stack<int> get_index_path(QTreeWidgetItem* item);
     VideoItem* get_video_item(VideoProject* v_proj, QTreeWidgetItem* s_item = nullptr);
     void get_video_items(QTreeWidgetItem* root, std::vector<VideoItem *> &items);
+    void get_analysis_items(QTreeWidgetItem* root, std::vector<AnalysisItem*> &items);
     void insert_to_path_index(VideoProject* vid_proj);
     void save_item_data(QTreeWidgetItem* item = nullptr);
     void add_analyses_to_item(VideoItem* v_item);
@@ -135,6 +136,7 @@ signals:
     void item_removed(VideoProject* vid_proj);
     void save_draw_wgt(QTreeWidgetItem* = nullptr);
     void clear_analysis();
+    void abort_all_analysis();
 };
 
 #endif // PROJECTWIDGET_H


### PR DESCRIPTION
Removed some options from the context menu before the analysis is done.
Now when the project would be closed it prompts the user if it wants to abort all the current running analyses, if not just cancel.

fix #73 and #19 .