### PR TITLE
Delete focus

### DIFF
--- a/ViAn/GUI/Bookmark/bookmarklist.cpp
+++ b/ViAn/GUI/Bookmark/bookmarklist.cpp
@@ -28,6 +28,11 @@ BookmarkList::BookmarkList(bool accept_container, int container_type, QWidget* p
     delete_sc->setContext(Qt::WidgetShortcut);
     connect(delete_sc, &QShortcut::activated, this, &BookmarkList::remove_item);
 
+    // Shortcut for renaming item
+    QShortcut* rename_sc = new QShortcut(QKeySequence(Qt::Key_F2), this);
+    rename_sc->setContext(Qt::WidgetShortcut);
+    connect(rename_sc, &QShortcut::activated, this, &BookmarkList::rename_item);
+
     clear();
 }
 
@@ -162,9 +167,9 @@ void BookmarkList::container_drop(BookmarkList *source, QDropEvent *event) {
  */
 void BookmarkList::rename_item(){
     bool ok;
-    switch (clicked_item->type()) {
+    switch (currentItem()->type()) {
     case BOOKMARK: {
-        auto item = dynamic_cast<BookmarkItem*>(clicked_item);
+        auto item = dynamic_cast<BookmarkItem*>(currentItem());
         BookmarkDialog dialog;
 
         dialog.setTextValue(QString::fromStdString(item->get_bookmark()->get_description()));
@@ -178,7 +183,7 @@ void BookmarkList::rename_item(){
         break;
     }
     case CONTAINER: {
-        auto item = dynamic_cast<BookmarkCategory*>(clicked_item);
+        auto item = dynamic_cast<BookmarkCategory*>(currentItem());
         QString text = QInputDialog::getText(nullptr, "Change title", "Enter a new title", QLineEdit::Normal, QString::fromStdString(item->get_name()), &ok);
         item->update_title(text);
         break;

--- a/ViAn/GUI/Bookmark/bookmarklist.cpp
+++ b/ViAn/GUI/Bookmark/bookmarklist.cpp
@@ -184,8 +184,16 @@ void BookmarkList::rename_item(){
     }
     case CONTAINER: {
         auto item = dynamic_cast<BookmarkCategory*>(currentItem());
-        QString text = QInputDialog::getText(nullptr, "Change title", "Enter a new title", QLineEdit::Normal, QString::fromStdString(item->get_name()), &ok);
-        item->update_title(text);
+
+        BookmarkDialog dialog;
+        dialog.setTextValue(QString::fromStdString(item->get_name()));
+        dialog.setLabelText("Enter a new category name");
+        dialog.setWindowTitle("Category name");
+        ok = dialog.exec();
+        QString new_text = dialog.textValue();
+        if (ok) {
+            item->update_title(new_text);
+        }
         break;
     }
     default:

--- a/ViAn/GUI/Bookmark/bookmarklist.cpp
+++ b/ViAn/GUI/Bookmark/bookmarklist.cpp
@@ -9,6 +9,8 @@
 #include <QDrag>
 #include <QApplication>
 #include <algorithm>
+#include <QShortcut>
+#include <QMessageBox>
 #include <QDebug>
 
 BookmarkList::BookmarkList(bool accept_container, int container_type, QWidget* parent) : QListWidget(parent) {
@@ -20,6 +22,11 @@ BookmarkList::BookmarkList(bool accept_container, int container_type, QWidget* p
     setAcceptDrops(true);
     setDropIndicatorShown(true);
     setIconSize(QSize(ImageGenerator::THUMBNAIL_SIZE, ImageGenerator::THUMBNAIL_SIZE));
+
+    // Shortcut for deleting item
+    QShortcut* delete_sc = new QShortcut(QKeySequence::Delete, this);
+    delete_sc->setContext(Qt::WidgetShortcut);
+    connect(delete_sc, &QShortcut::activated, this, &BookmarkList::remove_item);
 
     clear();
 }
@@ -186,6 +193,16 @@ void BookmarkList::rename_item(){
  * Removes the clicked list item
  */
 void BookmarkList::remove_item() {
+    QMessageBox msg_box;
+    msg_box.setIcon(QMessageBox::Warning);
+    msg_box.setText("Deleting item\n"
+                    "this will delete all bookmarks in all categories");
+    msg_box.setInformativeText("Are you sure?");
+    msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    msg_box.setDefaultButton(QMessageBox::No);
+    int reply = msg_box.exec();
+    if (reply == QMessageBox::No) return;
+
     if (currentItem()->type() == BOOKMARK) {
         BookmarkItem* bm_item = dynamic_cast<BookmarkItem*>(currentItem());
         Bookmark* b_mark = bm_item->get_bookmark();

--- a/ViAn/GUI/Bookmark/bookmarklist.cpp
+++ b/ViAn/GUI/Bookmark/bookmarklist.cpp
@@ -201,7 +201,7 @@ void BookmarkList::remove_item() {
     QMessageBox msg_box;
     msg_box.setIcon(QMessageBox::Warning);
     msg_box.setText("Deleting item\n"
-                    "this will delete all bookmarks in all categories");
+                    "this will delete all bookmarks in the categories");
     msg_box.setInformativeText("Are you sure?");
     msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msg_box.setDefaultButton(QMessageBox::No);

--- a/ViAn/GUI/drawingwidget.cpp
+++ b/ViAn/GUI/drawingwidget.cpp
@@ -378,7 +378,7 @@ void DrawingWidget::delete_item() {
         if (f_item->get_frame() == m_overlay->get_current_frame()) {
             QMessageBox msg_box;
             msg_box.setIcon(QMessageBox::Warning);
-            msg_box.setText("Deleting frameitem\n"
+            msg_box.setText("Deleting drawings on frame "+QString::number(f_item->get_frame())+"\n"
                             "This will delete all drawings on this frame");
             msg_box.setInformativeText("Do you wish to continue?");
             msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);

--- a/ViAn/GUI/drawingwidget.cpp
+++ b/ViAn/GUI/drawingwidget.cpp
@@ -5,6 +5,7 @@
 #include <QDropEvent>
 #include <QShortcut>
 #include <QColorDialog>
+#include <QMessageBox>
 
 DrawingWidget::DrawingWidget(QWidget *parent) : QTreeWidget(parent) {
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -20,9 +21,9 @@ DrawingWidget::DrawingWidget(QWidget *parent) : QTreeWidget(parent) {
     headerItem()->setText(1, "Color");
     headerItem()->setText(2, "Hide");
 
-    // Shortcut for deleteing item
-    QShortcut* delete_sc = new QShortcut(this);
-    delete_sc->setKey(QKeySequence(QKeySequence::Delete));
+    // Shortcut for deleting item
+    QShortcut* delete_sc = new QShortcut(QKeySequence::Delete, this);
+    delete_sc->setContext(Qt::WidgetWithChildrenShortcut);
     connect(delete_sc, &QShortcut::activated, this, &DrawingWidget::delete_item);
 
     connect(this, &DrawingWidget::currentItemChanged, this, [this]{ tree_item_clicked(currentItem());});
@@ -375,6 +376,16 @@ void DrawingWidget::delete_item() {
     if (item->type() == FRAME_ITEM) {
         FrameItem* f_item = dynamic_cast<FrameItem*>(item);
         if (f_item->get_frame() == m_overlay->get_current_frame()) {
+            QMessageBox msg_box;
+            msg_box.setIcon(QMessageBox::Warning);
+            msg_box.setText("Deleting frameitem\n"
+                            "This will delete all drawings on this frame");
+            msg_box.setInformativeText("Do you wish to continue?");
+            msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+            msg_box.setDefaultButton(QMessageBox::No);
+            int reply = msg_box.exec();
+            if (reply == QMessageBox::No) return;
+
             remove_from_tree(f_item);
             clearSelection();
         }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -78,6 +78,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(drawing_wgt, SIGNAL(clear_frame(int)), this, SLOT(clear(int)));
     connect(drawing_wgt, SIGNAL(update_text(QString, Shapes*)), this, SLOT(update_text(QString, Shapes*)));
     connect(project_wgt, &ProjectWidget::save_draw_wgt, drawing_wgt, &DrawingWidget::save_item_data);
+    connect(video_wgt, &VideoWidget::delete_sc_activated, drawing_wgt, &DrawingWidget::delete_item);
     
     // Initialize analysis queue widget
     queue_wgt = new QueueWidget();

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -47,6 +47,11 @@ ProjectWidget::ProjectWidget(QWidget *parent) : QTreeWidget(parent) {
     new_folder_sc->setKey(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_N));
     connect(new_folder_sc, &QShortcut::activated, this, &ProjectWidget::create_folder_item);
 
+    // Shortcut for deleting item
+    QShortcut* delete_sc = new QShortcut(QKeySequence::Delete, this);
+    delete_sc->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(delete_sc, &QShortcut::activated, this, &ProjectWidget::remove_item);
+
     connect(this, &ProjectWidget::itemSelectionChanged, this , &ProjectWidget::check_selection);
     connect(this, &ProjectWidget::currentItemChanged, this, &ProjectWidget::check_selection_level);
 

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -52,6 +52,11 @@ ProjectWidget::ProjectWidget(QWidget *parent) : QTreeWidget(parent) {
     delete_sc->setContext(Qt::WidgetWithChildrenShortcut);
     connect(delete_sc, &QShortcut::activated, this, &ProjectWidget::remove_item);
 
+    // Shortcut for updating drawing tag item
+    QShortcut* update_sc = new QShortcut(QKeySequence(Qt::Key_F5), this);
+    update_sc->setContext(Qt::WidgetShortcut);
+    connect(update_sc, &QShortcut::activated, this, &ProjectWidget::drawing_tag);
+
     connect(this, &ProjectWidget::itemSelectionChanged, this , &ProjectWidget::check_selection);
     connect(this, &ProjectWidget::currentItemChanged, this, &ProjectWidget::check_selection_level);
 
@@ -229,6 +234,7 @@ void ProjectWidget::add_tag(VideoProject* vid_proj, Tag* tag) {
         vid_item->addChild(item);
         clearSelection();
         item->setSelected(true);
+        setCurrentItem(item);
         for (auto t_frame : tag->tag_map) {
             TagFrameItem* tf_item = new TagFrameItem(t_frame.first);
             tf_item->set_state(t_frame.second);
@@ -241,6 +247,7 @@ void ProjectWidget::add_tag(VideoProject* vid_proj, Tag* tag) {
         vid_item->addChild(item);
         clearSelection();
         item->setSelected(true);
+        setCurrentItem(item);
         tree_item_clicked(item);
     }
     vid_item->setExpanded(true);
@@ -898,6 +905,8 @@ void ProjectWidget::drawing_tag() {
         delete selectedItems().front();
     } else if (selectedItems().front()->type() == VIDEO_ITEM) {
         vid_item = dynamic_cast<VideoItem*>(selectedItems().front());
+    } else {
+        return;
     }
     // Create tag drawing
     Tag* tag = new Tag("Drawing tag", true);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -325,6 +325,8 @@ void VideoWidget::set_btn_shortcuts() {
     video_end_sc = new QShortcut(QKeySequence(Qt::Key_End), this);
     page_step_front_sc = new QShortcut(QKeySequence(Qt::ALT + Qt::Key_Right), this);
     page_step_back_sc = new QShortcut(QKeySequence(Qt::ALT + Qt::Key_Left), this);
+    delete_sc = new QShortcut(QKeySequence::Delete, this);
+    delete_sc->setContext(Qt::WidgetWithChildrenShortcut);
 
     //connect
     connect(bookmark_quick_sc, &QShortcut::activated, this, &VideoWidget::quick_bookmark);
@@ -333,6 +335,7 @@ void VideoWidget::set_btn_shortcuts() {
     connect(video_end_sc, &QShortcut::activated, this, &VideoWidget::set_video_end);
     connect(page_step_front_sc, &QShortcut::activated, this, &VideoWidget::page_step_front);
     connect(page_step_back_sc, &QShortcut::activated, this, &VideoWidget::page_step_back);
+    connect(delete_sc, &QShortcut::activated, this, &VideoWidget::delete_sc_activated);
 }
 
 /**

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -109,6 +109,7 @@ signals:
     void tag_remove_frame(int);
     void set_status_bar(QString);
     void export_original_frame(VideoProject*, const int, cv::Mat);
+    void delete_sc_activated();
 public slots:
     void quick_analysis(AnalysisSettings*settings);
     void set_current_time(int time);
@@ -225,6 +226,7 @@ private:
     QShortcut* video_end_sc;
     QShortcut* page_step_front_sc;
     QShortcut* page_step_back_sc;
+    QShortcut* delete_sc;
 
     //Layouts
     QHBoxLayout* control_row;     // Container for all button areas


### PR DESCRIPTION
Pressing the shortcut delete now deletes different things depending on what widgets has focus. In the project widget it deletes the selected item, in drawing widget or video widget it deletes the current drawing with the same conditions as before and in bookmark widget (list) it deletes the selected bookmark or category. 

In bookmark widget the shortcut f2 now opens the change change destription dialog.
In project widget the shortcut f5 is added for updating the current drawing tag.
New dialog when changing the title of a category.