### PR TITLE
Small fixes

### DIFF
--- a/ViAn/GUI/Bookmark/bookmarklist.cpp
+++ b/ViAn/GUI/Bookmark/bookmarklist.cpp
@@ -94,7 +94,9 @@ void BookmarkList::item_right_clicked(const QPoint pos) {
     menu->addAction(rename, this, SLOT(rename_item()));
     menu->addAction("Delete", this, SLOT(remove_item()));
     menu->addSeparator();
-    menu->addAction("New category", this, SLOT(add_new_folder()));
+    if (m_container_type == UNSORTED) {
+        menu->addAction("New category", this, SLOT(add_new_folder()));
+    }
     menu->exec(mapToGlobal(pos));
     delete menu;
 }

--- a/ViAn/GUI/Bookmark/bookmarkwidget.cpp
+++ b/ViAn/GUI/Bookmark/bookmarkwidget.cpp
@@ -34,6 +34,7 @@ BookmarkWidget::BookmarkWidget(QWidget *parent) : QWidget(parent) {
 }
 
 void BookmarkWidget::generate_report() {
+    emit set_status_bar("Generating report. Please wait.");
     ReportContainer rp_cont;
     for(int i = 0; i != bm_list->count(); ++i){
         QListWidgetItem* item = bm_list->item(i);

--- a/ViAn/GUI/Bookmark/bookmarkwidget.h
+++ b/ViAn/GUI/Bookmark/bookmarkwidget.h
@@ -34,16 +34,17 @@ public:
     explicit BookmarkWidget(QWidget *parent = nullptr);
 signals:
     void play_bookmark_video(VideoProject* vid_proj, VideoState state);
+    void set_status_bar(QString);
 public slots:
     void create_bookmark(VideoProject *vid_proj, VideoState state, cv::Mat bookmark_frame, cv::Mat org_frame, QString time, QString description);
     void export_original_frame(VideoProject *vid_proj, const int frame_nbr, cv::Mat frame);
     void load_bookmarks(VideoProject *vid_proj);
     void set_path(std::string path);
     void clear_bookmarks();
+    void generate_report();
 private slots:
 //    void item_context_menu(QPoint pos);
 private:
-    void generate_report();
     BookmarkCategory* add_to_container(BookmarkItem* bm_item, std::pair<int, std::string> *container);
     QString get_input_text(QString text, bool* ok);
 };

--- a/ViAn/GUI/DrawingItems/frameitem.cpp
+++ b/ViAn/GUI/DrawingItems/frameitem.cpp
@@ -3,6 +3,7 @@
 FrameItem::FrameItem(int frame) : ShapeItem(FRAME_ITEM) {
     m_frame = frame;
     setFlags(flags() | Qt::ItemIsDropEnabled);
+    setFlags(flags() & ~Qt::ItemIsEditable);
     setText(0, QString::number(frame));
 }
 

--- a/ViAn/GUI/Toolbars/drawingtoolbar.cpp
+++ b/ViAn/GUI/Toolbars/drawingtoolbar.cpp
@@ -153,7 +153,7 @@ void DrawingToolbar::text_tool_clicked() {
     emit set_status_bar("Text tool");
     TextDialog* text_dialog = new TextDialog;
     text_dialog->deleteLater();
+    connect(text_dialog, &TextDialog::accepted, edit_tool_act, &QAction::trigger);
     connect(text_dialog, &TextDialog::text, this, &DrawingToolbar::send_text);
     text_dialog->exec();
-    edit_tool_act->trigger();
 }

--- a/ViAn/GUI/TreeItems/tagframeitem.cpp
+++ b/ViAn/GUI/TreeItems/tagframeitem.cpp
@@ -3,6 +3,7 @@
 TagFrameItem::TagFrameItem(int frame) : TreeItem(TAG_FRAME_ITEM) {
     m_frame = frame;
     setText(0, QString::number(m_frame));
+    setFlags(flags() & ~Qt::ItemIsEditable);
 }
 
 void TagFrameItem::set_state(TagFrame* t_frame) {

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -26,18 +26,18 @@
  */
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     QDockWidget* project_dock = new QDockWidget(tr("Projects"), this);
-    QDockWidget* bookmark_dock = new QDockWidget(tr("Bookmarks"), this);
     QDockWidget* drawing_dock = new QDockWidget(tr("Drawings"), this);
+    QDockWidget* bookmark_dock = new QDockWidget(tr("Bookmarks"), this);
     queue_dock = new QDockWidget(tr("Analysis queue"), this);
     ana_settings_dock = new QDockWidget(tr("Analysis settings"), this);
     project_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-    bookmark_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     drawing_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+    bookmark_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     queue_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     ana_settings_dock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     toggle_project_wgt = project_dock->toggleViewAction();
-    toggle_bookmark_wgt = bookmark_dock->toggleViewAction();
     toggle_drawing_wgt = drawing_dock->toggleViewAction();
+    toggle_bookmark_wgt = bookmark_dock->toggleViewAction();
     toggle_queue_wgt = queue_dock->toggleViewAction();
     toggle_ana_settings_wgt = ana_settings_dock->toggleViewAction();
 
@@ -61,12 +61,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, SIGNAL(begin_analysis(QTreeWidgetItem*, AnalysisMethod*)),
             analysis_wgt, SLOT(start_analysis(QTreeWidgetItem*, AnalysisMethod*)));
 
-    // Initialize bookmark widget
-    bookmark_wgt = new BookmarkWidget();
-    bookmark_wgt->setWindowFlags(Qt::Window);
-    addDockWidget(Qt::RightDockWidgetArea, bookmark_dock);
-    bookmark_dock->close();
-
     // Initialize drawing widget
     drawing_wgt = new DrawingWidget();
     drawing_dock->setWidget(drawing_wgt);
@@ -78,6 +72,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(drawing_wgt, SIGNAL(clear_frame(int)), this, SLOT(clear(int)));
     connect(drawing_wgt, SIGNAL(update_text(QString, Shapes*)), this, SLOT(update_text(QString, Shapes*)));
     connect(project_wgt, &ProjectWidget::save_draw_wgt, drawing_wgt, &DrawingWidget::save_item_data);
+
+    // Initialize bookmark widget
+    bookmark_wgt = new BookmarkWidget();
+    bookmark_wgt->setWindowFlags(Qt::Window);
+    addDockWidget(Qt::RightDockWidgetArea, bookmark_dock);
+    bookmark_dock->close();
     
     // Initialize analysis queue widget
     queue_wgt = new QueueWidget();

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -154,6 +154,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(this, SIGNAL(set_status_bar(QString)), status_bar, SLOT(on_set_status_bar(QString)));
     connect(video_wgt, SIGNAL(set_status_bar(QString)), status_bar, SLOT(on_set_status_bar(QString)));
     connect(project_wgt, SIGNAL(set_status_bar(QString)), status_bar, SLOT(on_set_status_bar(QString)));
+    connect(bookmark_wgt, SIGNAL(set_status_bar(QString)), status_bar, SLOT(on_set_status_bar(QString)));
     connect(draw_toolbar, SIGNAL(set_status_bar(QString)), status_bar, SLOT(on_set_status_bar(QString)));
     connect(analysis_wgt, &AnalysisWidget::add_analysis_bar, status_bar, &StatusBar::add_analysis_bar);
     connect(analysis_wgt, &AnalysisWidget::remove_analysis_bar, status_bar, &StatusBar::remove_analysis_bar);
@@ -564,7 +565,7 @@ void MainWindow::init_export_menu() {
     gen_report_act->setStatusTip(tr("Generate report"));
 
     connect(export_act, &QAction::triggered, this, &MainWindow::export_images);
-    connect(gen_report_act, &QAction::triggered, this, &MainWindow::gen_report);
+    connect(gen_report_act, &QAction::triggered, bookmark_wgt, &BookmarkWidget::generate_report);
 }
 
 /**
@@ -612,14 +613,6 @@ void MainWindow::zoom() {
 
 void MainWindow::move() {
     video_wgt->frame_wgt->set_tool(MOVE);
-}
-
-/**
- * @brief MainWindow::gen_report
- * runs when the generate report action is triggered
- */
-void MainWindow::gen_report() {
-    emit set_status_bar("Generating report. Please wait.");
 }
 
 void MainWindow::init_rp_dialog() {

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -53,7 +53,6 @@ public:
     RecentProjectDialog* rp_dialog;
 
 private slots:
-    void gen_report(void);
     void cont_bri(void);
     void export_images();
     void update_text(QString, Shapes*);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -274,10 +274,12 @@ void ProjectWidget::add_new_frame_to_tag_item(int frame, TagFrame* t_frame) {
         TagFrameItem* temp = dynamic_cast<TagFrameItem*>(m_tag_item->child(i));
         if (frame < temp->get_frame()) {
             m_tag_item->insertChild(i, tf_item);
+            setCurrentItem(tf_item);
             return;
         }
     }
     m_tag_item->addChild(tf_item);
+    setCurrentItem(tf_item);
 }
 
 /**

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -620,10 +620,11 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
     case SEQUENCE_ITEM: {
         auto seq_item = dynamic_cast<SequenceItem*>(item);
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item->parent()->parent());
-        vid_item->get_video_project()->get_video()->state.frame = seq_item->get_index();
+        VideoState state;
+        state = vid_item->get_video_project()->get_video()->state;
+        state.frame = seq_item->get_index();
         emit set_video_project(vid_item->get_video_project());
-        emit marked_video_state(vid_item->get_video_project(),
-                                vid_item->get_video_project()->get_video()->state);
+        emit marked_video_state(vid_item->get_video_project(), state);
 
         emit set_detections(false);
         emit set_poi_slider(false);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -241,7 +241,6 @@ void ProjectWidget::add_tag(VideoProject* vid_proj, Tag* tag) {
     vid_item->setExpanded(true);
 }
 
-
 /**
  * @brief ProjectWidget::add_frames_to_tag_item
  * Create the TagFrameItems from all the frames. Used when opening a project

--- a/ViAn/GUI/recentprojectdialog.cpp
+++ b/ViAn/GUI/recentprojectdialog.cpp
@@ -46,6 +46,7 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
         recent_list->addTopLevelItem(item);
     }
 
+    connect(recent_list, &QTreeWidget::itemSelectionChanged, this, &RecentProjectDialog::item_selection_changed);
     connect(recent_list, &QTreeWidget::itemDoubleClicked, this, &RecentProjectDialog::on_item_double_clicked);
     connect(new_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_new_btn_clicked);
     connect(browse_btn, &QPushButton::clicked, this, &RecentProjectDialog::on_browse_btn_clicked);
@@ -55,6 +56,19 @@ RecentProjectDialog::RecentProjectDialog(QWidget* parent) : QDialog(parent) {
 
 RecentProjectDialog::~RecentProjectDialog() {
     recent_list->clear();
+}
+
+/**
+ * @brief RecentProjectDialog::on_item_clicked
+ * Selects the open button
+ * @param item
+ */
+void RecentProjectDialog::item_selection_changed() {
+    if (recent_list->selectedItems().length() > 0) {
+        open_btn->setDefault(true);
+    } else {
+        new_btn->setDefault(true);
+    }
 }
 
 /**

--- a/ViAn/GUI/recentprojectdialog.h
+++ b/ViAn/GUI/recentprojectdialog.h
@@ -38,6 +38,7 @@ signals:
     void new_project(void);
     void remove_project();
 private slots:
+    void item_selection_changed();
     void on_item_double_clicked(QTreeWidgetItem *item);
     void on_new_btn_clicked();
     void on_browse_btn_clicked();

--- a/ViAn/GUI/textdialog.cpp
+++ b/ViAn/GUI/textdialog.cpp
@@ -44,7 +44,7 @@ void TextDialog::ok_btn_clicked() {
     } else {
         emit text(name->text(), double_box->value());
     }
-    close();
+    accept();
 }
 
 /**
@@ -52,5 +52,5 @@ void TextDialog::ok_btn_clicked() {
  * Close widget
  */
 void TextDialog::cancel_btn_clicked() {
-    close();
+    reject();
 }

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -245,7 +245,8 @@ void VideoWidget::set_btn_tool_tip() {
 
     fit_btn->setToolTip(tr("Scale video to screen: Ctrl + F"));
     original_size_btn->setToolTip(tr("Reset zoom: Ctrl + H"));
-    interpolate_check->setToolTip("Toggle between bicubic and nearest neighbor interpolation");
+    zoom_label->setToolTip("The zoom factor of the video: Z");
+    interpolate_check->setToolTip("Toggle between bicubic and nearest neighbor interpolation: N");
 
     fps_label->setToolTip("The frame rate of the video");
     set_start_interval_btn->setToolTip("Set left interval point: I");
@@ -320,6 +321,7 @@ void VideoWidget::set_btn_shortcuts() {
     set_end_interval_btn->setShortcut(QKeySequence(Qt::Key_O));
 
     bookmark_quick_sc = new QShortcut(QKeySequence(Qt::Key_B), this);
+    zoom_edit_sc = new QShortcut(QKeySequence(Qt::Key_Z), this);
     interpol_sc = new QShortcut(QKeySequence(Qt::Key_N), this);
     video_start_sc = new QShortcut(QKeySequence(Qt::Key_Home), this);
     video_end_sc = new QShortcut(QKeySequence(Qt::Key_End), this);
@@ -328,6 +330,7 @@ void VideoWidget::set_btn_shortcuts() {
 
     //connect
     connect(bookmark_quick_sc, &QShortcut::activated, this, &VideoWidget::quick_bookmark);
+    connect(zoom_edit_sc, &QShortcut::activated, this, &VideoWidget::zoom_label_focus);
     connect(interpol_sc, &QShortcut::activated, interpolate_check, &QCheckBox::toggle);
     connect(video_start_sc, &QShortcut::activated, this, &VideoWidget::set_video_start);
     connect(video_end_sc, &QShortcut::activated, this, &VideoWidget::set_video_end);
@@ -346,7 +349,7 @@ void VideoWidget::init_speed_slider() {
     speed_slider->setPageStep(1);
     speed_slider->setTickPosition(QSlider::TicksBelow);
     speed_slider->setEnabled(false);
-    speed_slider->setToolTip(tr("Adjust playback speed"));
+    speed_slider->setToolTip(tr("Adjust playback speed: * & /"));
     QLabel *label1 = new QLabel("1/8x", this);
     QLabel *label2 = new QLabel("1x", this);
     QLabel *label3 = new QLabel("8x", this);
@@ -456,9 +459,10 @@ void VideoWidget::init_playback_slider() {
     frame_line_edit = new QLineEdit("0", this);
 
     frame_line_edit->setFixedWidth(50);
+    frame_line_edit->setToolTip("Jump to frame: F");
 
-    frame_edit_act = new QShortcut(QKeySequence(Qt::Key_F), this);
-    connect(frame_edit_act, &QShortcut::activated, this, &VideoWidget::frame_label_focus);
+    frame_edit_sc = new QShortcut(QKeySequence(Qt::Key_F), this);
+    connect(frame_edit_sc, &QShortcut::activated, this, &VideoWidget::frame_label_focus);
 
     playback_slider = new AnalysisSlider(Qt::Horizontal);
 
@@ -1372,9 +1376,11 @@ void VideoWidget::zoom_label_finished() {
     } else {
         set_zoom_factor(converted);
         zoom_label->setText(QString::number(converted*PERCENT_INT_CONVERT) + "%");
+        zoom_label->clearFocus();
         return;
     }
     zoom_label->setText(QString::number(m_scale_factor*PERCENT_INT_CONVERT) + "%");
+    zoom_label->clearFocus();
 }
 
 int VideoWidget::get_brightness() {
@@ -1438,4 +1444,9 @@ void VideoWidget::page_step_back() {
 void VideoWidget::frame_label_focus() {
     frame_line_edit->setFocus();
     frame_line_edit->selectAll();
+}
+
+void VideoWidget::zoom_label_focus() {
+    zoom_label->setFocus();
+    zoom_label->selectAll();
 }

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -220,7 +220,8 @@ private:
     QShortcut* interpol_sc;
     QShortcut* speed_slider_up;
     QShortcut* speed_slider_down;
-    QShortcut* frame_edit_act;
+    QShortcut* frame_edit_sc;
+    QShortcut* zoom_edit_sc;
     QShortcut* video_start_sc;
     QShortcut* video_end_sc;
     QShortcut* page_step_front_sc;
@@ -277,6 +278,7 @@ private slots:
     void page_step_front(void);
     void page_step_back(void);
     void frame_label_focus(void);
+    void zoom_label_focus(void);
 
     void on_interpolate_toggled(bool checked);
 };

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -326,7 +326,6 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
     if (drawing) {
         emit set_tool_edit();
         drawing = false;
-        qDebug() << "release";
         return;
     }
     m_right_click = right_click;
@@ -341,7 +340,6 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
  */
 void Overlay::mouse_moved(QPoint pos, int frame_nr, bool shift, bool ctrl) {
     if (change_tool) return;
-    qDebug() << "move";
     update_drawing_position(pos, frame_nr, shift, ctrl);
 }
 

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -54,8 +54,6 @@ void Overlay::set_showing_overlay(bool value) {
 /**
  * @brief Overlay::set_tool
  * Sets the overlay tool's shape.
- * If the tool is the text-tool the user is prompted
- * to enter a text and a font scale.
  * @param s New tool to be set.
  */
 void Overlay::set_tool(SHAPES s) {
@@ -326,12 +324,11 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
         return;
     }
     if (drawing) {
-        drawing = false;
         emit set_tool_edit();
+        drawing = false;
+        qDebug() << "release";
         return;
     }
-    // TODO Should not need
-    //update_drawing_position(pos, frame_nr);
     m_right_click = right_click;
 }
 
@@ -344,6 +341,7 @@ void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
  */
 void Overlay::mouse_moved(QPoint pos, int frame_nr, bool shift, bool ctrl) {
     if (change_tool) return;
+    qDebug() << "move";
     update_drawing_position(pos, frame_nr, shift, ctrl);
 }
 
@@ -376,6 +374,7 @@ void Overlay::mouse_scroll(QPoint pos, int frame_nr) {
  * @param frame_nr Number of the frame currently shown in the video.
  */
 void Overlay::update_drawing_position(QPoint pos, int frame_nr, bool shift, bool ctrl) {
+    // Only update the overlay is is exists and is currently being shown
     if (show_overlay && !overlays[frame_nr].empty()) {
         if (current_shape == EDIT) {
             if (current_drawing == nullptr) return;

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -265,6 +265,28 @@ void Overlay::mouse_double_clicked(QPoint pos, int frame_nr) {
  */
 void Overlay::mouse_pressed(QPoint pos, int frame_nr, bool right_click) {
     if (show_overlay) {
+        if (current_shape == EDIT) {
+            prev_point = pos;
+            m_right_click = right_click;
+            if (right_click) {
+                if (current_drawing) {
+                    current_drawing->set_anchor(pos);
+                }
+                return;
+            }
+
+            if (current_drawing && point_in_drawing(pos, current_drawing)) {
+                return;
+            } else {
+                get_drawing(pos, frame_nr);
+            }
+            return;
+        }
+
+        if (right_click) {
+            emit set_tool_zoom();
+            return;
+        }
         switch (current_shape) {
         case RECTANGLE:
             add_drawing(new Rectangle(current_colour, pos), frame_nr);
@@ -285,22 +307,6 @@ void Overlay::mouse_pressed(QPoint pos, int frame_nr, bool right_click) {
         case PEN:
             add_drawing(new Pen(current_colour, pos), frame_nr);
             drawing = true;
-            break;
-        case EDIT:
-            prev_point = pos;
-            m_right_click = right_click;
-            if (right_click) {
-                if (current_drawing) {
-                    current_drawing->set_anchor(pos);
-                }
-                break;
-            }
-
-            if (current_drawing && point_in_drawing(pos, current_drawing)) {
-                break;
-            } else {
-                get_drawing(pos, frame_nr);
-            }
             break;
         default:
             break;

--- a/ViAn/Video/shapes/shapes.cpp
+++ b/ViAn/Video/shapes/shapes.cpp
@@ -91,6 +91,8 @@ void Shapes::update_text_draw_end() {
  * Adds the diff_pointer to the shape and therefore moves it that much
  */
 void Shapes::move_shape(QPoint diff_point) {
+    qDebug() << "moving" << diff_point;
+    qDebug() << "old" << draw_start.x << draw_start.y;
     draw_start += qpoint_to_point(diff_point);
     draw_end += qpoint_to_point(diff_point);
 }

--- a/ViAn/Video/shapes/shapes.cpp
+++ b/ViAn/Video/shapes/shapes.cpp
@@ -91,8 +91,6 @@ void Shapes::update_text_draw_end() {
  * Adds the diff_pointer to the shape and therefore moves it that much
  */
 void Shapes::move_shape(QPoint diff_point) {
-    qDebug() << "moving" << diff_point;
-    qDebug() << "old" << draw_start.x << draw_start.y;
     draw_start += qpoint_to_point(diff_point);
     draw_end += qpoint_to_point(diff_point);
 }


### PR DESCRIPTION
A lot of smaller changes.

- Right click to cancel drawing a drawing, will change to zoom/default tool.
- Open button in recent project dialog is selected as default when a project is selected in the recent list. This will make it so pressing enter will open the selected project.
- When creating a new tag it will be selected.
- Canceling or closing the text dialog for drawing a text will not change the tool to edit anymore.
- Clicking generate report in the menu now works and when creating a report the status bar is updated.
- Remove the "new category" option in the context menu for bookmarks in categories. This will prevent a category to be created inside another category.
- Can no longer change the name of tagframe items or the frameitem in the drawing widget.
- Reorder mainwindow so the context menu with the dockables is in the same order as the menus.
- Added shortcut and tooltip to the zoom factor field (Z).
- Updated tooltips for interpolate, speed slider and frame label to include the shortcuts.

Didn't feel like adding 10 (more) pull requests.