### PR TITLE
Image sequence path fix

### DIFF
--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1194,6 +1194,15 @@ bool ProjectWidget::save_project() {
             emit proj_path(m_proj->get_dir());
             QDir dir;
             dir.mkpath(QString::fromStdString(m_proj->get_dir()));
+
+            // If the current video is a sequence then it needs to be reloaded
+            // since the images path will have changed
+            for (auto vid_proj : m_proj->get_videos()) {
+                if (vid_proj->is_current() && vid_proj->get_video()->is_sequence()) {
+                    vid_proj->set_current(false);
+                    emit marked_video_state(vid_proj, vid_proj->get_video()->state);
+                }
+            }
         } else {
             // User aborted dialog, cancel save
             return false;
@@ -1211,7 +1220,7 @@ bool ProjectWidget::save_project() {
 
     RecentProject rp;
     rp.load_recent();
-    rp.update_recent(m_proj->get_name(), m_proj->get_file(), m_proj->get_last_changed());
+    rp.update_recent(m_proj->get_name(), m_proj->get_file(), m_proj->get_last_changed());    
     set_status_bar("Project saved");
     return true;
 }

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -926,7 +926,7 @@ void VideoWidget::load_marked_video_state(VideoProject* vid_proj, VideoState sta
     if (!frame_wgt->isVisible()) frame_wgt->show();
     if (!video_btns_enabled) set_video_btns(true);
 
-    if (m_vid_proj != vid_proj) {
+    if (!vid_proj->is_current()) {
         if (m_vid_proj) m_vid_proj->set_current(false);
         vid_proj->set_current(true);
 

--- a/ViAn/Project/imagesequence.cpp
+++ b/ViAn/Project/imagesequence.cpp
@@ -102,4 +102,9 @@ void ImageSequence::reorder_elem(const int &from, const int &to) {
     }
 }
 
+void ImageSequence::reset_root_dir(const std::string &dir) {
+    seq_path = dir + Project::SEQUENCE_FOLDER +  Utility::name_from_path(seq_path);
+    file_path = seq_path + "/" + get_pattern_name();
+}
+
 

--- a/ViAn/Project/imagesequence.h
+++ b/ViAn/Project/imagesequence.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "utility.h"
 #include <QJsonArray>
+#include "project.h"
 
 class ImageSequence : public Video {
 private:
@@ -20,6 +21,7 @@ public:
 
     void add_image(const std::string &image_path, const int& index=-1);
     void reorder_elem(const int& from, const int& to);
+    void reset_root_dir(const std::string &dir);
     int length();
 
     void read(const QJsonObject& json) override;

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -7,6 +7,7 @@
 const std::string Project::BOOKMARK_FOLDER = "Bookmarks/";
 const std::string Project::THUMBNAIL_FOLDER = "_thumbnails/";
 const std::string Project::STILLS_FOLDER = "Stills/";
+const std::string Project::SEQUENCE_FOLDER = "Sequences/";
 
 /**
  * @brief Project::Project

--- a/ViAn/Project/project.h
+++ b/ViAn/Project/project.h
@@ -56,6 +56,7 @@ public:
     static const std::string BOOKMARK_FOLDER;
     static const std::string THUMBNAIL_FOLDER;
     static const std::string STILLS_FOLDER;
+    static const std::string SEQUENCE_FOLDER;
 
     ID add_report(Report* report);
     ID add_video_project(VideoProject *vid_proj);

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -206,6 +206,13 @@ void VideoProject::set_project(Project *proj){
 }
 
 void VideoProject::reset_root_dir(const std::string &dir) {
+    if (m_video->is_sequence()) {
+        auto seq = dynamic_cast<ImageSequence*>(m_video);
+        if (seq) {
+            seq->reset_root_dir(dir);
+        }
+    }
+
     for(auto bm : m_bookmarks){
         bm.second->reset_root_dir(dir);
     }


### PR DESCRIPTION
The path to the copied images in sequences is now update correctly when saved. Fixes #92.

I used a tool _dos2unix_ to remove wierd line endings (^M) which made git think everything has changed in the imagesequence file.. The only changes I actually made in that file are in the `the reset_root_dir() `function