### PR TITLE
Analysis details fix

### DIFF
--- a/ViAn/GUI/Analysis/analysisslider.cpp
+++ b/ViAn/GUI/Analysis/analysisslider.cpp
@@ -157,6 +157,11 @@ void AnalysisSlider::set_analysis_proxy(AnalysisProxy *analysis) {
     }
 }
 
+/**
+ * @brief AnalysisSlider::set_details_checked
+ * Details_checked will be true when the details settings is checked
+ * @param b
+ */
 void AnalysisSlider::set_details_checked(bool b) {
     details_checked = b;
     repaint();
@@ -164,6 +169,8 @@ void AnalysisSlider::set_details_checked(bool b) {
 
 /**
  * @brief AnalysisSlider::set_show_ana_interval
+ * Show_ana_interval will be true when the details analysis interval should be shown.
+ * Only when an analysis is clicked
  * @param show
  */
 void AnalysisSlider::set_show_ana_interval(bool show) {

--- a/ViAn/GUI/Analysis/analysisslider.cpp
+++ b/ViAn/GUI/Analysis/analysisslider.cpp
@@ -63,7 +63,7 @@ void AnalysisSlider::paintEvent(QPaintEvent *ev) {
     }
 
     // Draws the analysis interval
-    if (show_ana_interval) {
+    if (details_checked && show_ana_interval) {
         brush = Qt::darkMagenta;
         draw_interval(m_ana_interval, groove_rect, frame_width);
         for (auto rect : interval_rects) {
@@ -157,13 +157,17 @@ void AnalysisSlider::set_analysis_proxy(AnalysisProxy *analysis) {
     }
 }
 
+void AnalysisSlider::set_details_checked(bool b) {
+    details_checked = b;
+    repaint();
+}
+
 /**
  * @brief AnalysisSlider::set_show_ana_interval
  * @param show
  */
 void AnalysisSlider::set_show_ana_interval(bool show) {
     show_ana_interval = show;
-    repaint();
 }
 
 /**

--- a/ViAn/GUI/Analysis/analysisslider.h
+++ b/ViAn/GUI/Analysis/analysisslider.h
@@ -24,6 +24,7 @@ class AnalysisSlider : public QSlider {
     bool show_on_slider = true;
     bool show_interval = true;
     bool show_ana_interval = false;
+    bool details_checked = false;
 
     const int JUMP_INTERVAL = 0;    //Change this to set how many frames the POI buttons should ignore
 
@@ -82,6 +83,7 @@ public slots:
     void set_show_on_slider(bool);
     void set_show_interval(bool);
     void set_show_ana_interval(bool);
+    void set_details_checked(bool);
 
     // Remove all displayed intervals of interest
     void clear_slider();

--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -151,11 +151,22 @@ void FrameWidget::set_detections_on_frame(int frame_num) {
     }
 }
 
+/**
+ * @brief FrameWidget::set_details_checked
+ * Details_checked will be true when the details setting is checked
+ * @param b
+ */
 void FrameWidget::set_details_checked(bool b) {
     details_checked = b;
     repaint();
 }
 
+/**
+ * @brief FrameWidget::set_show_box
+ * Show_box will be true when the details box should be shown.
+ * Only when an analysis is clicked
+ * @param b
+ */
 void FrameWidget::set_show_box(bool b) {
     show_box = b;
 }

--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -151,9 +151,13 @@ void FrameWidget::set_detections_on_frame(int frame_num) {
     }
 }
 
-void FrameWidget::show_bounding_box(bool b) {
-    show_box = b;
+void FrameWidget::set_details_checked(bool b) {
+    details_checked = b;
     repaint();
+}
+
+void FrameWidget::set_show_box(bool b) {
+    show_box = b;
 }
 
 void FrameWidget::set_detections(bool detections) {
@@ -300,7 +304,7 @@ void FrameWidget::paintEvent(QPaintEvent *event) {
         QRectF analysis(ana_rect_start, ana_rect_end);
         painter.drawRect(analysis);
     }
-    if (show_box && m_analysis != nullptr) {
+    if (details_checked && show_box && m_analysis != nullptr) {
         painter.setPen(QColor(180,200,200));
 
         auto box = m_analysis->settings->bounding_box;

--- a/ViAn/GUI/framewidget.h
+++ b/ViAn/GUI/framewidget.h
@@ -38,6 +38,7 @@ class FrameWidget : public QWidget
 
     // Analysis bounding box
     QPoint ana_rect_start, ana_rect_end;
+    bool details_checked = false;
     bool show_box = false;
 
     // Zoom
@@ -91,12 +92,13 @@ public slots:
     void copy();
     void paste();
     void on_new_image(cv::Mat org_image, cv::Mat mod_image, int frame_index);
-    void show_bounding_box(bool b);
+    void set_details_checked(bool b);
     void set_scroll_area_size(QSize size);
     void set_analysis(AnalysisProxy *);
     void clear_analysis();
     void set_video_project(VideoProject*);
     void set_detections_on_frame(int);
+    void set_show_box(bool);
     void set_detections(bool);
     void set_show_detections(bool);
     void set_tool(SHAPES m_tool);

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -182,13 +182,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::marked_analysis, video_wgt->frame_wgt, &FrameWidget::set_analysis);
     connect(project_wgt, &ProjectWidget::marked_analysis, video_wgt->playback_slider, &AnalysisSlider::set_analysis_proxy);
     connect(project_wgt, SIGNAL(marked_basic_analysis(BasicAnalysis*)), video_wgt->playback_slider, SLOT(set_basic_analysis(BasicAnalysis*)));
-    connect(ana_details_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::set_show_ana_interval);
-    connect(ana_details_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::show_bounding_box);
-    connect(ana_details_act, SIGNAL(toggled(bool)), project_wgt, SLOT(toggle_details(bool)));
+    connect(ana_details_act, &QAction::toggled, video_wgt->playback_slider, &AnalysisSlider::set_details_checked);
+    connect(ana_details_act, &QAction::toggled, video_wgt->frame_wgt, &FrameWidget::set_details_checked);
+    connect(ana_details_act, &QAction::toggled, project_wgt, &ProjectWidget::toggle_details);
     connect(toggle_ana_settings_wgt, SIGNAL(toggled(bool)), project_wgt, SLOT(toggle_settings(bool)));
     connect(project_wgt, &ProjectWidget::toggle_analysis_details, ana_details_act, &QAction::toggle);
     connect(project_wgt, &ProjectWidget::toggle_settings_details, toggle_ana_settings_wgt, &QAction::trigger);
 
+    connect(project_wgt, &ProjectWidget::set_show_analysis_details, video_wgt->frame_wgt, &FrameWidget::set_show_box);
+    connect(project_wgt, &ProjectWidget::set_show_analysis_details, video_wgt->playback_slider, &AnalysisSlider::set_show_ana_interval);
     connect(project_wgt, SIGNAL(set_detections(bool)), video_wgt->frame_wgt, SLOT(set_detections(bool)));
     connect(project_wgt, SIGNAL(enable_poi_btns(bool,bool)), video_wgt, SLOT(enable_poi_btns(bool,bool)));
     connect(project_wgt, SIGNAL(set_poi_slider(bool)), video_wgt->playback_slider, SLOT(set_show_pois(bool)));

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -646,6 +646,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         emit set_video_project(vid_item->get_video_project());
         emit marked_video_state(vid_item->get_video_project(), state);
 
+        emit set_show_analysis_details(false);
         emit set_detections(false);
         emit set_poi_slider(false);
         emit set_tag_slider(false);
@@ -660,6 +661,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
 
+        emit set_show_analysis_details(false);
         emit set_detections(false);
         emit set_poi_slider(false);
         emit set_tag_slider(false);
@@ -679,6 +681,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
 
+        emit set_show_analysis_details(true);
         emit set_detections(true);
         emit set_poi_slider(true);
         emit set_tag_slider(false);
@@ -699,6 +702,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
 
+        emit set_show_analysis_details(false);
         emit set_detections(false);
         emit set_poi_slider(false);
         emit set_tag_slider(true);
@@ -733,6 +737,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
 
+        emit set_show_analysis_details(false);
         emit set_detections(false);
         emit set_poi_slider(false);
         emit set_tag_slider(true);
@@ -746,6 +751,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         // TODO set from state
         // set brightness/contrast, rotation
 
+        emit set_show_analysis_details(false);
         emit set_detections(false);
         emit set_poi_slider(false);
         emit set_tag_slider(true);
@@ -1226,7 +1232,7 @@ bool ProjectWidget::save_project() {
 
     RecentProject rp;
     rp.load_recent();
-    rp.update_recent(m_proj->get_name(), m_proj->get_file(), m_proj->get_last_changed());    
+    rp.update_recent(m_proj->get_name(), m_proj->get_file(), m_proj->get_last_changed());
     set_status_bar("Project saved");
     return true;
 }
@@ -1328,7 +1334,7 @@ void ProjectWidget::remove_project() {
     QString text = "Are you sure you want to remove the project?";
     QString info_text = "This will delete all project files (images, reports, etc).";
     if (!message_box(text, info_text)) return;
-  
+
     set_main_window_name(QString::fromStdString(""));
     emit set_status_bar("Removing project and associated files");
 

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -64,6 +64,7 @@ signals:
     void update_settings_wgt(AnalysisSettings*);
     void show_analysis_settings(bool);
 
+    void set_show_analysis_details(bool);
     void set_detections(bool);
     void enable_poi_btns(bool, bool);
     void set_poi_slider(bool);
@@ -89,6 +90,7 @@ public slots:
     void add_new_frame_to_tag_item(int frame, TagFrame *t_frame);
     void remove_frame_from_tag_item(int frame);
     void set_tree_item_name(QTreeWidgetItem *item, QString);
+    void toggle_details(bool b);
     bool save_project();
     bool open_project(QString project_path="");
     bool close_project();
@@ -110,7 +112,6 @@ private slots:
     void remove_item();
     void rename_item();
     void drawing_tag();
-    void toggle_details(bool b);
     void toggle_settings(bool b);
     void update_settings();
     void create_folder_item();


### PR DESCRIPTION
The analysis details will now be hidden when they should and only be visible when the analysis is clicked from the project-tree and the details settings is checked.

Fixes #95 