### PR TITLE
Prevent the moving drawing bug.

### DIFF
--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -266,6 +266,7 @@ void Overlay::mouse_double_clicked(QPoint pos, int frame_nr) {
 void Overlay::mouse_pressed(QPoint pos, int frame_nr, bool right_click) {
     if (show_overlay) {
         if (current_shape == EDIT) {
+            edit = true;
             prev_point = pos;
             m_right_click = right_click;
             if (right_click) {
@@ -324,6 +325,7 @@ void Overlay::mouse_pressed(QPoint pos, int frame_nr, bool right_click) {
 void Overlay::mouse_released(QPoint pos, int frame_nr, bool right_click) {
     Q_UNUSED(pos)
     Q_UNUSED(frame_nr)
+    edit = false;
     if (change_tool) {
         emit set_tool_zoom();
         change_tool = false;
@@ -380,7 +382,7 @@ void Overlay::mouse_scroll(QPoint pos, int frame_nr) {
 void Overlay::update_drawing_position(QPoint pos, int frame_nr, bool shift, bool ctrl) {
     // Only update the overlay is is exists and is currently being shown
     if (show_overlay && !overlays[frame_nr].empty()) {
-        if (current_shape == EDIT) {
+        if (current_shape == EDIT && edit) {
             if (current_drawing == nullptr) return;
             if (m_right_click && current_drawing->get_shape() == TEXT) {
                 QPoint diff_point = pos - prev_point;

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -78,6 +78,7 @@ private:
     bool m_right_click = false;
     bool change_tool = false;
     bool drawing = false;
+    bool edit = false;
 
     bool show_overlay = true;
     int baseline = 0;


### PR DESCRIPTION
Added a variable to prevent the drawing from moving after finish drawing the drawing while moving the mouse. A mouse moved call was sent after the mouse released call which caused the drawing to be moved.

As far as I've tested it now works. To test it draw a drawing while moving the mouse quickly.

Fixes #86 