### PR TITLE
Playing a video in a floating widget will no longer update the state

### DIFF
--- a/ViAn/GUI/drawingwidget.cpp
+++ b/ViAn/GUI/drawingwidget.cpp
@@ -276,7 +276,12 @@ void DrawingWidget::tree_item_clicked(QTreeWidgetItem *item, const int &col) {
     switch (item->type()) {
     case FRAME_ITEM: {
         FrameItem* frame_item = dynamic_cast<FrameItem*>(item);
-        emit jump_to_frame(m_vid_proj, frame_item->get_frame());
+
+        VideoState state;
+        state = m_vid_proj->get_video()->state;
+        state.frame = frame_item->get_frame();
+
+        emit jump_to_frame(m_vid_proj, state);
         emit set_current_drawing(nullptr);
         break;
     }
@@ -297,7 +302,12 @@ void DrawingWidget::tree_item_clicked(QTreeWidgetItem *item, const int &col) {
         } else if (col == 2) {
             shape_item->update_show_icon(shape->toggle_show());
         }
-        emit jump_to_frame(m_vid_proj, shape->get_frame());
+
+        VideoState state;
+        state = m_vid_proj->get_video()->state;
+        state.frame = shape->get_frame();
+
+        emit jump_to_frame(m_vid_proj, state);
         emit set_current_drawing(shape);
         emit set_tool_edit();
         break;

--- a/ViAn/GUI/drawingwidget.h
+++ b/ViAn/GUI/drawingwidget.h
@@ -43,7 +43,7 @@ public slots:
     void item_changed(QTreeWidgetItem*);
 
 signals:
-    void jump_to_frame(VideoProject*, int);
+    void jump_to_frame(VideoProject*, VideoState);
     void set_current_drawing(Shapes* shape);
     void set_tool_edit();
     void set_tool_zoom();

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -70,7 +70,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     drawing_dock->setWidget(drawing_wgt);
     addDockWidget(Qt::LeftDockWidgetArea, drawing_dock);
     //connect(m_overlay, SIGNAL(new_drawing(Shapes*, int)), drawing_wgt, SLOT(add_drawing(Shapes*, int)));
-    connect(drawing_wgt, SIGNAL(jump_to_frame(VideoProject*,int)), video_wgt, SLOT(load_marked_video(VideoProject*, int)));
+    connect(drawing_wgt, &DrawingWidget::jump_to_frame, video_wgt, &VideoWidget::load_marked_video_state);
     connect(drawing_wgt, SIGNAL(set_current_drawing(Shapes*)), video_wgt, SLOT(set_current_drawing(Shapes*)));
     connect(drawing_wgt, SIGNAL(delete_drawing(Shapes*)), this, SLOT(delete_drawing(Shapes*)));
     connect(drawing_wgt, SIGNAL(clear_frame(int)), this, SLOT(clear(int)));

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -906,7 +906,9 @@ void VideoWidget::on_new_frame() {
     if (m_frame_rate) set_current_time(frame_num / m_frame_rate);
     frame_line_edit->setText(QString::number(frame_index.load()));
 
-    m_vid_proj->get_video()->state.frame = frame_num;
+    if (!m_floating) {
+        m_vid_proj->get_video()->state.frame = frame_num;
+    }
 
     playback_slider->update();
     frame_wgt->set_current_frame_nr(frame_num);
@@ -950,16 +952,6 @@ void VideoWidget::on_playback_slider_moved() {
         timer.restart();
     }
     on_new_frame();
-}
-
-// TODO Remove
-// All calls should go the load_marked_video_state
-// This is a temporary function until the other end is fixed
-void VideoWidget::load_marked_video(VideoProject *vid_proj, int frame) {
-    VideoState state;
-    state = vid_proj->get_video()->state;
-    state.frame =  frame;
-    load_marked_video_state(vid_proj, state);
 }
 
 /**

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -616,10 +616,12 @@ void VideoWidget::set_scale_factor(double scale_factor) {
  */
 void VideoWidget::set_zoom_state(QPoint center, double scale, int angle) {
     if (!m_vid_proj) return;
-    Video* video = m_vid_proj->get_video();
-    video->state.center = center;
-    video->state.scale_factor = scale;
-    video->state.rotation = angle;
+    if (!m_floating) {
+        Video* video = m_vid_proj->get_video();
+        video->state.center = center;
+        video->state.scale_factor = scale;
+        video->state.rotation = angle;
+    }
 }
 
 /**

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -139,7 +139,6 @@ public slots:
     void on_playback_slider_value_changed(void);
     void on_playback_slider_moved(void);
 
-    void load_marked_video(VideoProject *vid_proj, int frame);
     void load_marked_video_state(VideoProject *vid_proj, VideoState state);
     void clear_current_video();
     void remove_item(VideoProject* vid_proj);


### PR DESCRIPTION
To prevent the issue noted in #82 

Also removed load_marked_video function.

Fixes #96 