### PR TITLE
Clear videowidget when project closes

### DIFF
--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -64,6 +64,7 @@ private slots:
     void move();
     void open_widget(VideoProject *vid_proj);
     void close_widget(VideoWidget*);
+    void close_all_widgets();
 
 public slots:
     void options(void);
@@ -71,7 +72,6 @@ public slots:
     void open_project_folder();
     void show_analysis_dock(bool);
     void show_ana_settings_dock(bool);
-    void close_all_widgets();
 
 signals:
     void set_status_bar(QString);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1308,6 +1308,12 @@ bool ProjectWidget::close_project() {
 
     emit close_all_widgets();
 
+    emit set_show_analysis_details(false);
+    emit set_detections(false);
+    emit set_poi_slider(false);
+    emit set_tag_slider(false);
+    emit enable_poi_btns(false, false);
+
     // Remove project if temporary
     if (m_proj->is_temporary()) {
         m_proj->remove_files();


### PR DESCRIPTION
Couldn't reset it like I wanted to so hade to do the backup plan of just clearing some flags. But the analysisinterval is at least cleared from the slider now when the project closes.