### PR TITLE
Drawing resolution

### DIFF
--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -178,20 +178,22 @@ void FrameProcessor::process_frame() {
     //    cv::rectangle(tmp, view_rectangle.tl() * factor, view_rectangle.br() * factor, cv::Scalar(255,255,255), 2);
     //    cv::imshow("test", tmp); // can cause a deadlock
 
+    int frame_num = m_frame_index->load();
+
     // Draws the text drawings on the overlay
-    m_overlay->draw_overlay(manipulated_frame, m_frame_index->load());
+    m_overlay->draw_overlay(manipulated_frame, frame_num);
 
     // Apply zoom
     m_zoomer.scale_frame(manipulated_frame);
 
     // Draws the other drawings on the overlay
-    m_overlay->draw_overlay_scaled(manipulated_frame, m_frame_index->load(), Utility::from_qpoint(m_z_settings->anchor), m_z_settings->zoom_factor);
+    m_overlay->draw_overlay_scaled(manipulated_frame, frame_num, Utility::from_qpoint(m_z_settings->anchor), m_z_settings->zoom_factor);
 
     // Applies brightness and contrast
     m_manipulator.apply(manipulated_frame);
 
     // Emit manipulated frame and current frame number
-    emit done_processing(m_frame, manipulated_frame, m_frame_index->load());
+    emit done_processing(m_frame, manipulated_frame, frame_num);
 }
 
 /**

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -170,7 +170,7 @@ void FrameProcessor::process_frame() {
         cv::rotate(manipulated_frame, manipulated_frame, m_rotate_direction);
     }
 
-    // Create zoom perview mat
+    // Create zoom preview mat
     //    cv::Mat tmp = manipulated_frame.clone();
     //    double factor{0.5};
     //    cv::resize(tmp, tmp, cv::Size(), factor, factor);
@@ -178,11 +178,14 @@ void FrameProcessor::process_frame() {
     //    cv::rectangle(tmp, view_rectangle.tl() * factor, view_rectangle.br() * factor, cv::Scalar(255,255,255), 2);
     //    cv::imshow("test", tmp); // can cause a deadlock
 
-    // Draws the overlay
+    // Draws the text drawings on the overlay
     m_overlay->draw_overlay(manipulated_frame, m_frame_index->load());
 
     // Apply zoom
     m_zoomer.scale_frame(manipulated_frame);
+
+    // Draws the other drawings on the overlay
+    m_overlay->draw_overlay_scaled(manipulated_frame, m_frame_index->load(), Utility::from_qpoint(m_z_settings->anchor), m_z_settings->zoom_factor);
 
     // Applies brightness and contrast
     m_manipulator.apply(manipulated_frame);
@@ -215,11 +218,13 @@ void FrameProcessor::load_zoomer_state() {
  * Emitts all signals that sends zoom data
  */
 void FrameProcessor::emit_zoom_data() {
-        m_z_settings->zoom_factor = m_zoomer.get_scale_factor();
+    // Store changes made
+    m_z_settings->zoom_factor = m_zoomer.get_scale_factor();
+    m_z_settings->anchor = m_zoomer.get_anchor();
 
-        emit set_zoom_state(m_zoomer.get_center(), m_zoomer.get_scale_factor(), m_zoomer.get_angle());
-        emit set_anchor(m_zoomer.get_anchor());
-        emit set_scale_factor(m_zoomer.get_scale_factor());
+    emit set_zoom_state(m_zoomer.get_center(), m_zoomer.get_scale_factor(), m_zoomer.get_angle());
+    emit set_anchor(m_zoomer.get_anchor());
+    emit set_scale_factor(m_zoomer.get_scale_factor());
 }
 
 /**
@@ -270,9 +275,6 @@ void FrameProcessor::update_zoomer_settings() {
     else if (m_zoomer.get_interpolation_method() != m_z_settings->interpolation){
         m_zoomer.set_interpolation_method(m_z_settings->interpolation);
     }
-
-    // Store changes made
-    m_z_settings->zoom_factor = m_zoomer.get_scale_factor();
 
     emit_zoom_data();
 }

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -20,15 +20,40 @@ Overlay::~Overlay() {
 
 /**
  * @brief Overlay::draw_overlay
- * Draws an overlay on top of the specified frame.
+ * Draws the text drawings from an overlay on top of the specified frame.
  * @param img Frame to draw on
  * @param frame_nr Number of the frame currently shown in the video.
  */
 void Overlay::draw_overlay(cv::Mat &frame, int frame_nr) {
     if (show_overlay) {
         for (auto it = overlays[frame_nr].begin(); it != overlays[frame_nr].end(); it++) {
-            if ((*it)->get_show()) {
+            // Only draw the text drawings
+            if ((*it)->get_show() && (*it)->get_shape() == TEXT) {
                 frame = (*it)->draw(frame);
+            }
+        }
+    }
+    current_frame = frame_nr;
+}
+
+/**
+ * @brief Overlay::draw_overlay_scaled
+ * Draws the non-text drawings from an overlay on top of the specified frame.
+ * These drawings are scaled to fit the Mat
+ * @param img - Frame to draw on
+ * @param frame_nr - Number of the frame currently shown in the video.
+ * @param anchor - The top left coordinate of the zoomrect, used to scale the drawings
+ * @param scale_factor - The zoom percent, used to scale the drawings
+ */
+void Overlay::draw_overlay_scaled(cv::Mat &frame, int frame_nr, cv::Point anchor, double scale_factor) {
+    if (show_overlay) {
+        for (auto it = overlays[frame_nr].begin(); it != overlays[frame_nr].end(); it++) {
+            // Don't draw text drawings since they work a little different.
+            // They can't be scaled as big and small as needed the same way as other drawings
+            // They are drawing first and then scaled with the Mat
+            if ((*it)->get_show() && (*it)->get_shape() != TEXT) {
+                // The anchor and scale factor is used to scale the drawing
+                frame = (*it)->draw_scaled(frame, anchor, scale_factor);
             }
         }
     }

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -36,6 +36,7 @@ public:
     bool is_showing_overlay();
     void set_showing_overlay(bool value);
     void draw_overlay(cv::Mat &frame, int frame_nr);
+    void draw_overlay_scaled(cv::Mat &frame, int frame_nr, cv::Point anchor, double scale_factor);
 
     void create_text(QPoint, int);
     void set_text_settings(QString text, float font_scale);

--- a/ViAn/Video/shapes/arrow.cpp
+++ b/ViAn/Video/shapes/arrow.cpp
@@ -28,6 +28,19 @@ cv::Mat Arrow::draw(cv::Mat &frame) {
 }
 
 /**
+ * @brief Arrow::draw_scaled
+ * Scales and draws the object on top the specified frame.
+ * @param frame - Frame to draw on.
+ * @param anchor - Top left corner in zoomrect, used to scale drawing.
+ * @param scale_factor - Zoom factor, used to scale drawing.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat Arrow::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    cv::arrowedLine(frame, (draw_start-anchor)*scale_factor, (draw_end-anchor)*scale_factor, color, thickness);
+    return frame;
+}
+
+/**
  * @brief Arrow::handle_new_pos
  * Function to handle the new position of the mouse.
  * Does not need to store the new position.

--- a/ViAn/Video/shapes/arrow.h
+++ b/ViAn/Video/shapes/arrow.h
@@ -9,6 +9,7 @@ public:
     Arrow(QColor col, QPoint pos);
     ~Arrow() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
     void read(const QJsonObject& json) override;

--- a/ViAn/Video/shapes/circle.cpp
+++ b/ViAn/Video/shapes/circle.cpp
@@ -30,6 +30,23 @@ cv::Mat Circle::draw(cv::Mat &frame) {
 }
 
 /**
+ * @brief Circle::draw_scaled
+ * Scales and draws the object on top the specified frame.
+ * @param frame - Frame to draw on.
+ * @param anchor - Top left corner in zoomrect, used to scale drawing.
+ * @param scale_factor - Zoom factor, used to scale drawing.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat Circle::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    cv::Rect rect((draw_start-anchor)*scale_factor, (draw_end-anchor)*scale_factor);
+    cv::Size size = rect.size();
+    cv::Point center = (rect.br() + rect.tl())*0.5;
+    cv::RotatedRect bounding_rect(center, size, 0);
+    cv::ellipse(frame, bounding_rect, color, thickness);
+    return frame;
+}
+
+/**
  * @brief Circle::handle_new_pos
  * Function to handle the new position of the mouse.
  * Does not need to store the new position.

--- a/ViAn/Video/shapes/circle.h
+++ b/ViAn/Video/shapes/circle.h
@@ -9,6 +9,7 @@ public:
     Circle(QColor col, QPoint pos);
     ~Circle() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
     void read(const QJsonObject& json) override;

--- a/ViAn/Video/shapes/line.cpp
+++ b/ViAn/Video/shapes/line.cpp
@@ -28,6 +28,19 @@ cv::Mat Line::draw(cv::Mat &frame) {
 }
 
 /**
+ * @brief Line::draw_scaled
+ * Scales and draws the object on top the specified frame.
+ * @param frame - Frame to draw on.
+ * @param anchor - Top left corner in zoomrect, used to scale drawing.
+ * @param scale_factor - Zoom factor, used to scale drawing.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat Line::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    cv::line(frame, (draw_start-anchor)*scale_factor, (draw_end-anchor)*scale_factor, color, thickness);
+    return frame;
+}
+
+/**
  * @brief Line::handle_new_pos
  * Function to handle the new position of the mouse.
  * Does not need to store the new position.

--- a/ViAn/Video/shapes/line.h
+++ b/ViAn/Video/shapes/line.h
@@ -9,6 +9,7 @@ public:
     Line(QColor col, QPoint pos);
     ~Line() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
     void read(const QJsonObject& json) override;

--- a/ViAn/Video/shapes/pen.cpp
+++ b/ViAn/Video/shapes/pen.cpp
@@ -35,12 +35,27 @@ cv::Mat Pen::draw(cv::Mat &frame) {
         p = point;
     }
     return frame;
-    
-    
-//    for (std::pair<cv::Point, cv::Point> line : lines) {
-//        cv::line(frame, line.first, line.second, color, thickness);
-//    }
-//    return frame;
+}
+
+/**
+ * @brief Pen::draw_scaled
+ * Scales and draws the object on top the specified frame.
+ * @param frame - Frame to draw on.
+ * @param anchor - Top left corner in zoomrect, used to scale drawing.
+ * @param scale_factor - Zoom factor, used to scale drawing.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat Pen::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    cv::Point p(-1, -1);
+    for (auto point : points) {
+        if (p.x < 0 || p.y < 0) {
+            p = point;
+            continue;
+        }
+        cv::line(frame, (p-anchor)*scale_factor, (point-anchor)*scale_factor, color, thickness);
+        p = point;
+    }
+    return frame;
 }
 
 /**

--- a/ViAn/Video/shapes/pen.h
+++ b/ViAn/Video/shapes/pen.h
@@ -9,6 +9,7 @@ public:
     Pen(QColor col, QPoint pos);
     ~Pen() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void move_shape(QPoint p) override;
     void write(QJsonObject& json) override;

--- a/ViAn/Video/shapes/rectangle.cpp
+++ b/ViAn/Video/shapes/rectangle.cpp
@@ -29,6 +29,20 @@ cv::Mat Rectangle::draw(cv::Mat &frame) {
 }
 
 /**
+ * @brief Rectangle::draw_scaled
+ * Scales and draws the object on top the specified frame.
+ * @param frame - Frame to draw on.
+ * @param anchor - Top left corner in zoomrect, used to scale drawing.
+ * @param scale_factor - Zoom factor, used to scale drawing.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat Rectangle::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    cv::Rect rect((draw_start-anchor)*scale_factor, (draw_end-anchor)*scale_factor);
+    cv::rectangle(frame, rect, color, thickness);
+    return frame;
+}
+
+/**
  * @brief Rectangle::handle_new_pos
  * Function to handle the new position of the mouse.
  * Does not need to store the new position.

--- a/ViAn/Video/shapes/rectangle.h
+++ b/ViAn/Video/shapes/rectangle.h
@@ -9,6 +9,7 @@ public:
     Rectangle(QColor col, QPoint pos);
     ~Rectangle() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
     void read(const QJsonObject& json) override;

--- a/ViAn/Video/shapes/shapes.h
+++ b/ViAn/Video/shapes/shapes.h
@@ -25,6 +25,7 @@ public:
     virtual void move_shape(QPoint p);
     virtual void handle_new_pos(QPoint pos) = 0;
     virtual cv::Mat draw(cv::Mat &frame) = 0;
+    virtual cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) = 0;
 
     virtual void read(const QJsonObject& json) = 0;
     virtual void write(QJsonObject& json) = 0;

--- a/ViAn/Video/shapes/text.cpp
+++ b/ViAn/Video/shapes/text.cpp
@@ -37,6 +37,12 @@ cv::Mat Text::draw(cv::Mat &frame) {
     return frame;
 }
 
+cv::Mat Text::draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) {
+    Q_UNUSED (anchor)
+    Q_UNUSED (scale_factor)
+    return draw(frame);
+}
+
 /**
  * @brief Text::handle_new_pos
  * Function to handle the new position of the mouse.

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -9,6 +9,7 @@ public:
     Text(QColor col, QPoint pos, QString strng, double fnt_scl);
     ~Text() override;
     cv::Mat draw(cv::Mat &frame) override;
+    cv::Mat draw_scaled(cv::Mat &frame, cv::Point anchor, double scale_factor) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
     void read(const QJsonObject& json) override;


### PR DESCRIPTION
Drawings are now scaled and drawn after the Mat is scaled. This gives them a lot better resolution as they are always drawn in the current resolution.

The text drawing are an exception as is functions differently. As it doesn't have a start and end point as the other drawings and just a start and a text size it's not possibly to scale it the same way. So text drawings are still drawn as they used to.