### PR TITLE
Fix crash when removing drawing tag

### DIFF
--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -744,7 +744,7 @@ void VideoWidget::tag_frame() {
  * Un-tags the current frame
  */
 void VideoWidget::remove_tag_frame() {
-    if (m_tag != nullptr) {
+    if (m_tag != nullptr && !m_tag->is_drawing_tag()) {
         if (m_tag->find_frame(playback_slider->value())) {
             m_tag->remove_frame(playback_slider->value());
             emit tag_remove_frame(playback_slider->value());


### PR DESCRIPTION
Using the shortcut to remove a tag while on a drawingtagframe caused a crash. Added a check to fix that.

Fixes #128 