### PR TITLE
Fix an incorrect scaling when starting an analysis

### DIFF
--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -566,11 +566,10 @@ void FrameWidget::set_analysis_settings() {
         AnalysisSettings* settings = new AnalysisSettings(MOTION_DETECTION);
         settings->quick_analysis = true;
 
-        cv::Point end = cv::Point(ana_rect_end.x(), ana_rect_end.y());
-        cv::Point start (ana_rect_start.x(), ana_rect_start.y());
-        cv::Rect scaled = cv::Rect(cv::Point(anchor.x()/m_scale_factor + start.x/m_scale_factor, anchor.y()/m_scale_factor + start.y/m_scale_factor),
-                      cv::Point(anchor.x()/m_scale_factor + end.x/m_scale_factor, anchor.y()/m_scale_factor + end.y/m_scale_factor));
-        settings->set_bounding_box(scaled);
+        QPoint scaled_start = scale_point(ana_rect_start);
+        QPoint scaled_end = scale_point(ana_rect_end);
+        QRect scaled_rect(scaled_start, scaled_end);
+        settings->set_bounding_box(Utility::from_qrect(scaled_rect));
 
         emit quick_analysis(settings);
         emit set_toolbar_zoom();


### PR DESCRIPTION
The analysis will now be done on the correct rectangle.

Fixes #135 