### PR TITLE
Moved the show framewidget call

### DIFF
--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -291,6 +291,7 @@ void FrameWidget::on_new_image(cv::Mat org_image, cv::Mat mod_image, int frame_i
     _qimage = QImage(_tmp_frame.data, _tmp_frame.cols, _tmp_frame.rows, _tmp_frame.cols*3, QImage::Format_RGB888);
     setFixedSize(_qimage.size());
     set_detections_on_frame(frame_index);
+    if (!isVisible()) show();
     repaint();
 }
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -970,7 +970,6 @@ void VideoWidget::on_playback_slider_moved() {
  * @param vid_proj
  */
 void VideoWidget::load_marked_video_state(VideoProject* vid_proj, VideoState state) {
-    if (!frame_wgt->isVisible()) frame_wgt->show();
     if (!video_btns_enabled) set_video_btns(true);
 
     if (!vid_proj->is_current() || m_vid_proj == nullptr) {


### PR DESCRIPTION
Move the call to make the frame widget visible again to where the frame actually loads

Fixed #139 