### PR TITLE
Delete analysis fixes

### DIFF
--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -988,6 +988,10 @@ void ProjectWidget::update_settings() {
  * If a folder is selected then it will delete all subitems as well.
  */
 void ProjectWidget::remove_item() {
+    if (!dynamic_cast<AnalysisItem*>(currentItem())->is_finished()) {
+        return;
+    }
+
     QString text = "Deleting item(s)\n"
                    "(Unselected items within selected folders will be deleted as well)";
     QString info_text = "Do you wish to continue?";

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -622,6 +622,9 @@ bool ProjectWidget::prompt_save() {
         case QMessageBox::Cancel:
                 ok = false;
                 break;
+        case QMessageBox::No:
+                remove_list.clear();
+                break;
     }
     return ok;
 }
@@ -1098,7 +1101,7 @@ void ProjectWidget::remove_analysis_item(QTreeWidgetItem* item) {
     VideoItem* vid_item = dynamic_cast<VideoItem*>(item->parent());
     AnalysisProxy* analysis = dynamic_cast<AnalysisItem*>(item)->get_analysis();
 
-    analysis->delete_saveable(analysis->full_path());
+    remove_list.push_back(analysis->full_path());
     vid_item->get_video_project()->remove_analysis(analysis);
     emit clear_analysis();
 }
@@ -1186,6 +1189,14 @@ bool ProjectWidget::save_project() {
         msg_box.exec();
         return false;
     }
+
+    for (std::string path : remove_list) {
+        QFile file(QString::fromStdString(path));
+        if(file.exists()) {
+            file.remove();
+        }
+    }
+    remove_list.clear();
 
     // Move all project files if the current project is temporary
     // i.e. has not been saved yet

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -51,6 +51,8 @@ public:
     QPointer<QAction> show_settings_act = nullptr;
     QString get_default_path();
 
+    std::vector<std::string> remove_list;
+
 signals:
     void selected_media();
     void marked_video_state(VideoProject *vid_proj, VideoState state);


### PR DESCRIPTION
No longer able to delete not-yet-done analyses with the delete shortcut. Added a check to prevent it.

When removing an analysis the path to the analysis is saved in a list and the file in the folder in untouched. Later when the project is saved the list of "removed" project is removed from the folder. If the project is not saved, the list is just cleared so the file are still in the folder.

Fixes #129 
Fixes #134 