### PR TITLE
Speed slider slow down

### DIFF
--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -522,9 +522,15 @@ void VideoWidget::init_playback_slider() {
 
 void VideoWidget::stop_btn_clicked() {
     set_status_bar("Stop");
-    frame_index.store(0);
+
+    {
+        std::lock_guard<std::mutex> lk(player_lock);
+        frame_index.store(0);
+    }
+
     is_playing.store(false);
     play_btn->setChecked(false);
+
     on_new_frame();
 }
 
@@ -894,6 +900,7 @@ void VideoWidget::set_slider_max(int value) {
  */
 void VideoWidget::on_new_frame() {
     int frame_num = frame_index.load();
+    qDebug() << frame_num;
     if (frame_num == m_frame_length - 1) play_btn->setChecked(false);
     if (analysis_only) {
         if (!playback_slider->is_in_POI(frame_num)) {
@@ -922,6 +929,7 @@ void VideoWidget::on_new_frame() {
 
     playback_slider->update();
     frame_wgt->set_current_frame_nr(frame_num);
+    player_con.notify_one();
 }
 
 /**

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -114,6 +114,7 @@ void VideoPlayer::check_events() {
                 wait_load_read();
             } else if (current_frame != m_frame->load() && m_video_loaded->load()) {
                 set_frame();
+                qDebug() << "after set frame";
             }
         } else {
             // Timer condition triggered. Update playback speed if nessecary and read new frame
@@ -124,6 +125,7 @@ void VideoPlayer::check_events() {
 
             // Timer condition triggered. Read new frame
             if (m_is_playing->load()) {
+                qDebug() << "else is playing";
                 std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
                 if (!synced_read()) continue;
                 ++*m_frame;

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -117,7 +117,7 @@ void VideoPlayer::check_events() {
                 set_frame();
             }
 
-            // Timer condition triggered. Update playback speed if nessecary and read new frame
+            // Update playback speed if nessecary and read new frame
             int speed = m_speed_step->load();
             if (speed != m_cur_speed_step) {
                 set_playback_speed(speed);


### PR DESCRIPTION
Updating the frame on the video by drawing the slider or clicking next frame is no longer tied to the speed slider's value.

Added notifys when the analysis slider value is changed to increase the speed and added some locks in the videowidget to prevent som sync problems.

Fixes #151 