### PR TITLE
State on video

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -119,7 +119,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     manipulator_dock->close();
 
     connect(manipulator_wgt, &ManipulatorWidget::values, video_wgt, &VideoWidget::update_brightness_contrast);
-    connect(manipulator_wgt, &ManipulatorWidget::update_tag, video_wgt, &VideoWidget::update_tag);
+    connect(manipulator_wgt, &ManipulatorWidget::update_tag, video_wgt, &VideoWidget::update_tag_color);
 
     // Main toolbar
     main_toolbar = new MainToolbar();
@@ -186,6 +186,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(project_wgt, &ProjectWidget::clear_tag, video_wgt, &VideoWidget::clear_tag);
     connect(project_wgt, &ProjectWidget::set_video_project, video_wgt->frame_wgt, &FrameWidget::set_video_project);
     connect(project_wgt, &ProjectWidget::set_video_project, drawing_wgt, &DrawingWidget::set_video_project);
+    connect(project_wgt, &ProjectWidget::update_tag, video_wgt, &VideoWidget::update_tag);
 
     connect(project_wgt, &ProjectWidget::project_closed, drawing_wgt, &DrawingWidget::clear_overlay);
     connect(project_wgt, &ProjectWidget::project_closed, video_wgt, &VideoWidget::clear_current_video);

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -181,6 +181,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent){
     connect(video_wgt,   &VideoWidget::export_original_frame, bookmark_wgt, &BookmarkWidget::export_original_frame);
     connect(project_wgt, &ProjectWidget::clear_slider, video_wgt->playback_slider, &AnalysisSlider::clear_slider);
     connect(project_wgt, &ProjectWidget::marked_video_state, video_wgt, &VideoWidget::load_marked_video_state);
+    connect(project_wgt, &ProjectWidget::item_type, video_wgt, &VideoWidget::set_item_type);
     connect(video_wgt, &VideoWidget::update_manipulator_wgt, manipulator_wgt, &ManipulatorWidget::set_values);
     connect(project_wgt, &ProjectWidget::clear_tag, video_wgt, &VideoWidget::clear_tag);
     connect(project_wgt, &ProjectWidget::set_video_project, video_wgt->frame_wgt, &FrameWidget::set_video_project);

--- a/ViAn/GUI/manipulatorwidget.cpp
+++ b/ViAn/GUI/manipulatorwidget.cpp
@@ -34,10 +34,10 @@ ManipulatorWidget::ManipulatorWidget(int b, double c, QWidget* parent) : QWidget
     brightness_slider->setValue(brightness);
     brightness_value_label->setText(QString::number(brightness_slider->value()));
 
-    contrast_slider->setSingleStep(FrameManipulator().CONTRAST_STEP*DOUBLE_TO_INT);
-    contrast_slider->setMaximum(FrameManipulator().CONTRAST_MAX*DOUBLE_TO_INT);
-    contrast_slider->setMinimum(FrameManipulator().CONTRAST_MIN*DOUBLE_TO_INT);
-    contrast_slider->setValue(contrast*DOUBLE_TO_INT);
+    contrast_slider->setSingleStep(static_cast<int>(FrameManipulator().CONTRAST_STEP*DOUBLE_TO_INT));
+    contrast_slider->setMaximum(static_cast<int>(FrameManipulator().CONTRAST_MAX*DOUBLE_TO_INT));
+    contrast_slider->setMinimum(static_cast<int>(FrameManipulator().CONTRAST_MIN*DOUBLE_TO_INT));
+    contrast_slider->setValue(static_cast<int>(contrast*DOUBLE_TO_INT));
     contrast_value_label->setText(QString::number(contrast_slider->value()/DOUBLE_TO_INT));
 
     connect(brightness_slider, &QSlider::valueChanged, this, &ManipulatorWidget::b_changed);
@@ -89,8 +89,7 @@ void ManipulatorWidget::ok_clicked() {
  */
 void ManipulatorWidget::default_clicked() {
     brightness_slider->setValue(FrameManipulator().BRIGHTNESS_DEFAULT);
-    contrast_slider->setValue(FrameManipulator().CONTRAST_DEFAULT*DOUBLE_TO_INT);
-    apply_btn->setDisabled(true);
+    contrast_slider->setValue(static_cast<int>(FrameManipulator().CONTRAST_DEFAULT*DOUBLE_TO_INT));
     emit values(brightness_slider->value(), contrast_slider->value()/DOUBLE_TO_INT, true);
 }
 
@@ -129,7 +128,7 @@ void ManipulatorWidget::c_changed(int value) {
 void ManipulatorWidget::set_values(int b_value, double c_value) {
     blockSignals(true);
     brightness_slider->setValue(b_value);
-    contrast_slider->setValue(c_value*DOUBLE_TO_INT);
+    contrast_slider->setValue(static_cast<int>(c_value*DOUBLE_TO_INT));
     blockSignals(false);
     apply_btn->setDisabled(true);
 }

--- a/ViAn/GUI/manipulatorwidget.cpp
+++ b/ViAn/GUI/manipulatorwidget.cpp
@@ -50,10 +50,17 @@ ManipulatorWidget::ManipulatorWidget(int b, double c, QWidget* parent) : QWidget
 
     // Button setup
     btn_box = new QDialogButtonBox(Qt::Horizontal, this);
-    btn_box->addButton(QDialogButtonBox::Ok)->setText("Apply");
+
+    apply_btn = new QPushButton(tr("&Apply"));
+
+    btn_box->addButton(apply_btn, QDialogButtonBox::AcceptRole);
     btn_box->addButton(QDialogButtonBox::RestoreDefaults)->setText("Default");
 
-    connect(btn_box->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, &ManipulatorWidget::ok_clicked);
+    apply_btn->setDisabled(true);
+    QString default_tool_tip = "Brightness: "+QString::number(FrameManipulator().BRIGHTNESS_DEFAULT)+"\nContrast: "+QString::number(FrameManipulator().CONTRAST_DEFAULT);
+    btn_box->button(QDialogButtonBox::RestoreDefaults)->setToolTip(default_tool_tip);
+
+    connect(apply_btn, &QPushButton::clicked, this, &ManipulatorWidget::ok_clicked);
     connect(btn_box->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, &ManipulatorWidget::default_clicked);
 
     layout->addWidget(btn_box);
@@ -70,6 +77,7 @@ ManipulatorWidget::ManipulatorWidget(int b, double c, QWidget* parent) : QWidget
 void ManipulatorWidget::ok_clicked() {
     int b = brightness_slider->value();
     double c = contrast_slider->value()/DOUBLE_TO_INT;
+    apply_btn->setDisabled(true);
     emit values(b, c, true);
     emit update_tag(b, c);
 }
@@ -82,6 +90,7 @@ void ManipulatorWidget::ok_clicked() {
 void ManipulatorWidget::default_clicked() {
     brightness_slider->setValue(FrameManipulator().BRIGHTNESS_DEFAULT);
     contrast_slider->setValue(FrameManipulator().CONTRAST_DEFAULT*DOUBLE_TO_INT);
+    apply_btn->setDisabled(true);
     emit values(brightness_slider->value(), contrast_slider->value()/DOUBLE_TO_INT, true);
 }
 
@@ -93,6 +102,7 @@ void ManipulatorWidget::default_clicked() {
  */
 void ManipulatorWidget::b_changed(int value) {
     brightness_value_label->setText(QString::number(value));
+    apply_btn->setDisabled(false);
     emit values(brightness_slider->value(), contrast_slider->value()/DOUBLE_TO_INT, false);
 }
 
@@ -105,6 +115,7 @@ void ManipulatorWidget::b_changed(int value) {
 void ManipulatorWidget::c_changed(int value) {
     QString text = QString::number(value/DOUBLE_TO_INT);
     contrast_value_label->setText(text);
+    apply_btn->setDisabled(false);
     emit values(brightness_slider->value(), contrast_slider->value()/DOUBLE_TO_INT, false);
 }
 
@@ -120,4 +131,5 @@ void ManipulatorWidget::set_values(int b_value, double c_value) {
     brightness_slider->setValue(b_value);
     contrast_slider->setValue(c_value*DOUBLE_TO_INT);
     blockSignals(false);
+    apply_btn->setDisabled(true);
 }

--- a/ViAn/GUI/manipulatorwidget.h
+++ b/ViAn/GUI/manipulatorwidget.h
@@ -23,6 +23,7 @@ class ManipulatorWidget : public QWidget {
     QSlider* brightness_slider;
     QSlider* contrast_slider;
     QDialogButtonBox* btn_box;
+    QPushButton* apply_btn;
 
 signals:
     void values(int b_value, double c_value, bool update);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -658,7 +658,8 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
         emit set_video_project(vid_item->get_video_project());
         VideoState state;
-        state = vid_item->get_video_project()->get_video()->state;
+        vid_item->get_video_project()->state.video = true;
+        state = vid_item->get_video_project()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
 
         emit set_show_analysis_details(false);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -773,12 +773,13 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
             m_tag_item = tag_item;
         } else if (item->parent()->type() == DRAWING_TAG_ITEM) {
             emit marked_video_state(vid_item->get_video_project(), state);
-            emit item_type(DRAWING_TAG_ITEM);
+            emit item_type(item->type());
             DrawingTagItem* dt_item = dynamic_cast<DrawingTagItem*>(item->parent());
             emit marked_basic_analysis(dt_item->get_tag());
             if (m_tag_item) m_tag_item->setCheckState(0, Qt::Unchecked);
             m_tag_item = nullptr;
         }
+        break;
     } case FOLDER_ITEM: {
         emit item_type(item->type());
         break;
@@ -902,6 +903,7 @@ void ProjectWidget::context_menu(const QPoint &point) {
                 if (item->parent()->type() == TAG_ITEM) {
                     menu.addAction("Delete", this, SLOT(remove_item()));
                 }
+                break;
             default:
                 break;
         }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -645,6 +645,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state.frame = seq_item->get_index();
         emit set_video_project(vid_item->get_video_project());
         emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
         emit set_show_analysis_details(false);
         emit set_detections(false);
@@ -661,6 +662,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         vid_item->get_video_project()->state.video = true;
         state = vid_item->get_video_project()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
         emit set_show_analysis_details(false);
         emit set_detections(false);
@@ -681,6 +683,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         VideoState state;
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
         emit set_show_analysis_details(true);
         emit set_detections(true);
@@ -702,6 +705,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         VideoState state;
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
         emit set_show_analysis_details(false);
         emit set_detections(false);
@@ -728,15 +732,12 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
             item->setCheckState(0, Qt::Checked);
             m_tag_item = tag_item;
         }
-        // If the current selected tag already is the current tag, deselect it
-        else if (m_tag_item == tag_item) {
-            update_current_tag(nullptr);
-        }
 
         emit set_video_project(vid_item->get_video_project());
         VideoState state;
         state = vid_item->get_video_project()->get_video()->state;
         emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
         emit set_show_analysis_details(false);
         emit set_detections(false);
@@ -762,6 +763,7 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
         state = tf_item->get_state();
         if (item->parent()->type() == TAG_ITEM) {
             emit marked_video_state(vid_item->get_video_project(), state);
+            emit item_type(item->type());
 
             TagItem* tag_item = dynamic_cast<TagItem*>(item->parent());
             emit marked_basic_analysis(tag_item->get_tag());
@@ -771,12 +773,14 @@ void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
             m_tag_item = tag_item;
         } else if (item->parent()->type() == DRAWING_TAG_ITEM) {
             emit marked_video_state(vid_item->get_video_project(), state);
+            emit item_type(DRAWING_TAG_ITEM);
             DrawingTagItem* dt_item = dynamic_cast<DrawingTagItem*>(item->parent());
             emit marked_basic_analysis(dt_item->get_tag());
             if (m_tag_item) m_tag_item->setCheckState(0, Qt::Unchecked);
             m_tag_item = nullptr;
         }
     } case FOLDER_ITEM: {
+        emit item_type(item->type());
         break;
     } default:
         break;

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -39,7 +39,7 @@ ProjectWidget::ProjectWidget(QWidget *parent) : QTreeWidget(parent) {
     connect(show_settings_act, SIGNAL(triggered()), this, SIGNAL(toggle_settings_details()));
 
     connect(this, &ProjectWidget::customContextMenuRequested, this, &ProjectWidget::context_menu);
-    connect(this, &ProjectWidget::currentItemChanged, this, &ProjectWidget::tree_item_clicked);
+    connect(this, &ProjectWidget::currentItemChanged, this, &ProjectWidget::tree_item_changed);
 
     // Widget only shortcut for creating a new folder
     QShortcut* new_folder_sc = new QShortcut(this);
@@ -241,14 +241,14 @@ void ProjectWidget::add_tag(VideoProject* vid_proj, Tag* tag) {
             item->addChild(tf_item);
         }
         item->setExpanded(true);
-        tree_item_clicked(item);
+        tree_item_changed(item);
     } else if (!tag->is_drawing_tag()) {
         TagItem* item = new TagItem(tag);
         vid_item->addChild(item);
         clearSelection();
         item->setSelected(true);
         setCurrentItem(item);
-        tree_item_clicked(item);
+        tree_item_changed(item);
     }
     vid_item->setExpanded(true);
 }
@@ -627,13 +627,14 @@ bool ProjectWidget::prompt_save() {
 }
 
 /**
- * @brief ProjectWidget::tree_item_clicked
- * Slot function for when a tree item is clicked.
+ * @brief ProjectWidget::tree_item_changed
+ * Slot function for when the current tree item is changed.
  * Performs different operations based on tree item type.
- * @param item
- * @param col
+ * @param item          : new tree item
+ * @param prev_item     : previous tree item
  */
-void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, QTreeWidgetItem* prev_item) {
+void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* prev_item) {
+    qDebug() << "item changed";
     Q_UNUSED(prev_item)
     if (!item) return;
     switch(item->type()){

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -39,7 +39,7 @@ ProjectWidget::ProjectWidget(QWidget *parent) : QTreeWidget(parent) {
     connect(show_settings_act, SIGNAL(triggered()), this, SIGNAL(toggle_settings_details()));
 
     connect(this, &ProjectWidget::customContextMenuRequested, this, &ProjectWidget::context_menu);
-    connect(this, SIGNAL(itemClicked(QTreeWidgetItem*,int)), this, SLOT(tree_item_clicked(QTreeWidgetItem*,int)));
+    connect(this, &ProjectWidget::currentItemChanged, this, &ProjectWidget::tree_item_clicked);
 
     // Widget only shortcut for creating a new folder
     QShortcut* new_folder_sc = new QShortcut(this);
@@ -633,8 +633,8 @@ bool ProjectWidget::prompt_save() {
  * @param item
  * @param col
  */
-void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, const int& col) {
-    Q_UNUSED(col)
+void ProjectWidget::tree_item_clicked(QTreeWidgetItem* item, QTreeWidgetItem* prev_item) {
+    Q_UNUSED(prev_item)
     if (!item) return;
     switch(item->type()){
     case SEQUENCE_ITEM: {
@@ -900,6 +900,7 @@ void ProjectWidget::context_menu(const QPoint &point) {
                 menu.addAction("Tag drawings", this, SLOT(drawing_tag()));
                 break;
             case TAG_FRAME_ITEM:
+                menu.addAction("Update", this, SIGNAL(update_tag()));
                 if (item->parent()->type() == TAG_ITEM) {
                     menu.addAction("Delete", this, SLOT(remove_item()));
                 }

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -78,6 +78,7 @@ signals:
     void remove_overlay();
     void new_vid_proj(VideoProject*);
     void item_type(int);
+    void update_tag();
 
 public slots:
     void new_project(void);
@@ -116,7 +117,7 @@ private slots:
     void drawing_tag();
     void update_settings();
     void create_folder_item();
-    void tree_item_clicked(QTreeWidgetItem *item, const int& col = 0);
+    void tree_item_clicked(QTreeWidgetItem *item, QTreeWidgetItem *prev_item = nullptr);
     void check_selection();
     void check_selection_level(QTreeWidgetItem* current, QTreeWidgetItem* prev);
 

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -117,7 +117,7 @@ private slots:
     void drawing_tag();
     void update_settings();
     void create_folder_item();
-    void tree_item_clicked(QTreeWidgetItem *item, QTreeWidgetItem *prev_item = nullptr);
+    void tree_item_changed(QTreeWidgetItem *item, QTreeWidgetItem *prev_item = nullptr);
     void check_selection();
     void check_selection_level(QTreeWidgetItem* current, QTreeWidgetItem* prev);
 

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -40,7 +40,7 @@ class ProjectWidget : public QTreeWidget
                                 "mts", "avi", "mov", "qt", "wmv", "mp4",
                                 "m4p", "m4v", "mpg", "mp2", "mpeg",
                                 "mpe", "mpv", "m2v", "m4v", "3gp", "3g2",
-                                "flv", "f4v", "f4p", "f4a", "f4b"};
+                                "flv", "f4v", "f4p", "f4a", "f4b", "webm"};
 public:
     explicit ProjectWidget(QWidget *parent = nullptr);
     ~ProjectWidget();

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -77,6 +77,7 @@ signals:
     void update_slider();
     void remove_overlay();
     void new_vid_proj(VideoProject*);
+    void item_type(int);
 
 public slots:
     void new_project(void);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1479,6 +1479,10 @@ double VideoWidget::get_contrast() {
 
 void VideoWidget::set_brightness_contrast(int bri, double cont) {
     if (!m_vid_proj) return;
+    if (state_video) {
+        m_vid_proj->state.brightness = bri;
+        m_vid_proj->state.contrast = cont;
+    }
     m_vid_proj->get_video()->state.brightness = bri;
     m_vid_proj->get_video()->state.contrast = cont;
 }

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1364,6 +1364,7 @@ void VideoWidget::on_original_size(){
  * @param c_val contrast value
  */
 void VideoWidget::update_brightness_contrast(int b_val, double c_val, bool update) {
+    if (state_video) update = true;
     update_processing_settings([&](){
         m_settings.brightness = b_val;
         m_settings.contrast = c_val;

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -917,6 +917,9 @@ void VideoWidget::on_new_frame() {
     frame_line_edit->setText(QString::number(frame_index.load()));
 
     if (!m_floating) {
+        if (state_video) {
+            m_vid_proj->state.frame = frame_num;
+        }
         m_vid_proj->get_video()->state.frame = frame_num;
     }
 
@@ -972,6 +975,11 @@ void VideoWidget::on_playback_slider_moved() {
 void VideoWidget::load_marked_video_state(VideoProject* vid_proj, VideoState state) {
     if (!frame_wgt->isVisible()) frame_wgt->show();
     if (!video_btns_enabled) set_video_btns(true);
+    if (state.video) {
+        state_video = true;
+    } else {
+        state_video = false;
+    }
 
     if (!vid_proj->is_current() || m_vid_proj == nullptr) {
         if (m_vid_proj) m_vid_proj->set_current(false);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1509,6 +1509,8 @@ void VideoWidget::set_brightness_contrast(int bri, double cont) {
         m_vid_proj->state.brightness = bri;
         m_vid_proj->state.contrast = cont;
     }
+    m_vid_proj->get_video()->state.brightness = bri;
+    m_vid_proj->get_video()->state.contrast = cont;
 }
 
 void VideoWidget::speed_up_activate() {

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -712,11 +712,12 @@ void VideoWidget::play_btn_toggled(bool status) {
     }
 }
 
+
 void VideoWidget::update_tag(int b, double c) {
     if (proj_tree_item == TAG_FRAME_ITEM) {
         m_tag->update_color_correction(playback_slider->value(), b, c);
         emit set_status_bar("Frame number: " + QString::number(playback_slider->value()) + " updated");
-    } else if (proj_tree_item == TAG_ITEM) {
+    } else if (proj_tree_item == TAG_ITEM || proj_tree_item == DRAWING_TAG_ITEM) {
         m_tag->update_color_whole_tag(b, c);
         emit set_status_bar("Whole tag '"+ QString::fromStdString(m_tag->get_name()) +"' updated");
     }

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -617,6 +617,11 @@ void VideoWidget::set_scale_factor(double scale_factor) {
 void VideoWidget::set_zoom_state(QPoint center, double scale, int angle) {
     if (!m_vid_proj) return;
     if (!m_floating) {
+        if (state_video) {
+            m_vid_proj->state.center = center;
+            m_vid_proj->state.scale_factor = scale;
+            m_vid_proj->state.rotation = angle;
+        }
         Video* video = m_vid_proj->get_video();
         video->state.center = center;
         video->state.scale_factor = scale;

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -250,6 +250,7 @@ private:
     VideoProject* m_vid_proj = nullptr;
     Tag* m_tag = nullptr;
     bool m_floating = false;
+    bool state_video = false;
 
     bool tag_clicked = false;
 

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -38,6 +38,7 @@ private:
     QSize current_frame_size;
     QTime timer;
 
+    int proj_tree_item = 1001;      // Default is VIDEO_ITEM, based on ITEM_TYPE on treeitem
     int prev_frame_idx;
     int POI_end;
     double m_scale_factor = 1;
@@ -142,6 +143,7 @@ public slots:
     void on_playback_slider_moved(void);
 
     void load_marked_video_state(VideoProject *vid_proj, VideoState state);
+    void set_item_type(int);
     void clear_current_video();
     void remove_item(VideoProject* vid_proj);
 

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -122,7 +122,8 @@ public slots:
     void set_scale_factor(double);
     void set_zoom_state(QPoint, double, int);
     void play_btn_toggled(bool status);
-    void update_tag(int b, double c);
+    void update_tag();
+    void update_tag_color(int b, double c);
     void tag_frame();
     void remove_tag_frame(void);
     void new_tag_clicked();

--- a/ViAn/Project/Analysis/tag.cpp
+++ b/ViAn/Project/Analysis/tag.cpp
@@ -30,11 +30,31 @@ void Tag::remove_frame(int frame) {
     }
 }
 
+/**
+ * @brief Tag::update_color_correction
+ * Update the current tag_frame's color correction
+ * @param frame     : Frame number of the tag_frame
+ * @param b_value   : brightness value
+ * @param c_value   : contrast value
+ */
 void Tag::update_color_correction(int frame, int b_value, double c_value) {
     auto it = tag_map.find(frame);
     if (it != tag_map.end()) {
         (*it).second->update_color_correction(b_value, c_value);
         m_unsaved_changes = true;
+    }
+}
+
+/**
+ * @brief Tag::update_color_whole_tag
+ * Updates the color correction on all tag_frames in the current tag
+ * @param b     : brightness value
+ * @param c     : contrast value
+ */
+void Tag::update_color_whole_tag(int b, double c) {
+    for (auto it = tag_map.begin(); it != tag_map.end(); ++it) {
+        (*it).second->m_state.brightness = b;
+        (*it).second->m_state.contrast = c;
     }
 }
 

--- a/ViAn/Project/Analysis/tag.h
+++ b/ViAn/Project/Analysis/tag.h
@@ -21,6 +21,7 @@ public:
     bool find_frame(int);
     void remove_frame(int);
     void update_color_correction(int frame, int b_value, double c_value);
+    void update_color_whole_tag(int b, double c);
     int next_frame(int);
     int previous_frame(int);
     std::vector<int> get_frames();

--- a/ViAn/Project/video.h
+++ b/ViAn/Project/video.h
@@ -21,6 +21,7 @@ struct VideoState {
     // Center point is relative the rotation
     QPoint center = QPoint(-1,-1);
     cv::Rect zoom_rect;
+    bool video = false;
     VideoState(){}
     VideoState(VideoState&rh){
         frame = rh.frame;
@@ -31,6 +32,7 @@ struct VideoState {
         anchor = rh.anchor;
         center = rh.center;
         zoom_rect = rh.zoom_rect;
+        video = rh.video;
     }
 };
 

--- a/ViAn/Project/videoproject.h
+++ b/ViAn/Project/videoproject.h
@@ -41,6 +41,8 @@ public:
     VideoProject();
     ~VideoProject();
 
+    VideoState state;
+
     Q_DECL_DEPRECATED ID id;
 
     void read(const QJsonObject& json);

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -300,9 +300,7 @@ void FrameProcessor::update_manipulator_settings() {
     update_rotation(rotate_direction);
     m_man_settings->rotate = 0;
     emit set_zoom_state(m_zoomer.get_center(), m_zoomer.get_scale_factor(), m_zoomer.get_angle());
-    if (m_man_settings->update_state) {
-        emit set_bri_cont(m_manipulator.get_brightness(), m_manipulator.get_contrast());
-    }
+    emit set_bri_cont(m_manipulator.get_brightness(), m_manipulator.get_contrast());
 }
 
 /**


### PR DESCRIPTION
Gave the video its own state which will update directly when the sliders in the manipulatorwidget are changed.

The apply button will update the current selected tag_frame or all tag_frames in the current label depending on what is selected in the project tree. It will also be disabled when the values haven't changed.