### PR TITLE
Clean videowidget when "new project" is selected

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -109,6 +109,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     zoom_preview_dock->setWidget(zoom_wgt);
     addDockWidget(Qt::RightDockWidgetArea, zoom_preview_dock);
 
+    connect(video_wgt, &VideoWidget::clean_zoom_preview, zoom_wgt, &ZoomPreviewWidget::clean_zoom_widget);
     connect(video_wgt, &VideoWidget::zoom_preview, zoom_wgt, &ZoomPreviewWidget::frame_update);
     connect(zoom_wgt, &ZoomPreviewWidget::window_size, video_wgt, &VideoWidget::update_zoom_preview_size);
     connect(zoom_preview_dock, &QDockWidget::topLevelChanged, zoom_wgt, &ZoomPreviewWidget::on_floating_changed);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1087,6 +1087,8 @@ void VideoWidget::clear_current_video() {
     zoom_label->setText("100%");
 
     frame_wgt->close();
+    m_vid_proj = nullptr;
+    m_tag = nullptr;
     emit clean_zoom_preview();
 }
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1087,6 +1087,7 @@ void VideoWidget::clear_current_video() {
     zoom_label->setText("100%");
 
     frame_wgt->close();
+    emit clean_zoom_preview();
 }
 
 void VideoWidget::set_video_btns(bool b) {

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1082,6 +1082,9 @@ void VideoWidget::clear_current_video() {
     play_btn->setChecked(false);
     playback_slider->set_interval(-1, -1);
     set_total_time(0);
+    fps_label->setText("Fps: -");
+    max_frames->setText("/ -");
+    zoom_label->setText("100%");
 
     frame_wgt->close();
 }
@@ -1430,11 +1433,13 @@ void VideoWidget::rotate_ccw(){
  * @param lambda function where the variable is changed
  */
 void VideoWidget::update_processing_settings(std::function<void ()> lambda) {
-    v_sync.lock.lock();
-    lambda();
-    settings_changed.store(true);
-    v_sync.lock.unlock();
-    v_sync.con_var.notify_all();
+    if (!frame_wgt->isHidden()) {
+        v_sync.lock.lock();
+        lambda();
+        settings_changed.store(true);
+        v_sync.lock.unlock();
+        v_sync.con_var.notify_all();
+    }
 }
 
 void VideoWidget::update_playback_speed(int speed) {

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -109,6 +109,7 @@ public:
     void set_delete_drawing(Shapes* shape);
 
 signals:
+    void clean_zoom_preview();
     void close_video_widget(VideoWidget*);
     void new_bookmark(VideoProject*, VideoState, cv::Mat, cv::Mat, QString, QString);
     void set_detections_on_frame(int);

--- a/ViAn/GUI/zoompreviewwidget.cpp
+++ b/ViAn/GUI/zoompreviewwidget.cpp
@@ -74,6 +74,18 @@ void ZoomPreviewWidget::frame_update(cv::Mat preview_image) {
 }
 
 /**
+ * @brief ZoomPreviewWidget::clean_zoom_widget
+ * Clean the zoom preview widget from the last image and paint in to the background color
+ */
+void ZoomPreviewWidget::clean_zoom_widget() {
+    _qimage = QImage(_tmp.cols, _tmp.rows, QImage::Format_RGB32);
+    _qimage.fill(QColor(240, 240, 240));
+    QSize s = _qimage.size();
+    center_image(s);
+    update();
+}
+
+/**
  * @brief ZoomPreviewWidget::on_floating_changed
  * @param is_floating
  */

--- a/ViAn/GUI/zoompreviewwidget.h
+++ b/ViAn/GUI/zoompreviewwidget.h
@@ -30,6 +30,7 @@ signals:
 
 public slots:
     void frame_update(cv::Mat frame);
+    void clean_zoom_widget();
     void on_floating_changed(const bool is_floating);
 };
 


### PR DESCRIPTION
FPS, number of frames and zoom label are cleaned when opening a new project.

Also fixed a crash when resizing the window after selecting a new project. (Calling process frame when the frame widget is hidden). This will also prevent the old frame to popup after, for example, full screening or popping out the zoom preview dockable.

Fixes #175 