### PR TITLE
Fix crash when clicking placeholder

### DIFF
--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -696,6 +696,7 @@ void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* pr
         break;
     } case VIDEO_ITEM: {
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
+        if (vid_item->get_video_project() == nullptr) return;
         emit set_video_project(vid_item->get_video_project());
         VideoState state;
         vid_item->get_video_project()->state.video = true;


### PR DESCRIPTION
Can be hard to test but this is a fix to prevent a crash after something has gone wrong. Since when the item has the text placeholder it doesn't have a videoproject stored, I just return when that happend.