### PR TITLE
Fixed some cases where slider went outside the interval while ana btn

### DIFF
--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -273,12 +273,8 @@ private:
     Interval* m_current_interval = nullptr;
 
     bool m_floating = false;
-    bool state_video = false;
     bool frame_is_clean = false;
 
-    bool tag_clicked = false;
-
-    bool slider_is_blocked = false;
     bool video_btns_enabled = false;
     bool analysis_only = false;
 


### PR DESCRIPTION
Fixes some cases where the slider would go outside the interval while the analysis play button was checked.

Fixed pressing next/prev frame, playbutton and clicking on slider.

Also removed some unused variables.

Fixes #189 