### PR TITLE
Zoom preview panning

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -118,6 +118,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     connect(video_wgt, &VideoWidget::clean_zoom_preview, zoom_wgt, &ZoomPreviewWidget::clean_zoom_widget);
     connect(video_wgt, &VideoWidget::zoom_preview, zoom_wgt, &ZoomPreviewWidget::frame_update);
     connect(zoom_wgt, &ZoomPreviewWidget::window_size, video_wgt, &VideoWidget::update_zoom_preview_size);
+    connect(zoom_wgt, &ZoomPreviewWidget::pan_translation, video_wgt, &VideoWidget::translate_zoom_from_preview_click);
     connect(zoom_preview_dock, &QDockWidget::topLevelChanged, zoom_wgt, &ZoomPreviewWidget::on_floating_changed);
     
     // Initialize analysis queue widget

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1655,19 +1655,12 @@ void VideoWidget::update_zoom_preview_size(QSize s) {
  * and updates the frame processor so that the viewport will center around that position.
  * @param click_pos:    The coordinate where the click occured (zoom preview coordinates)
  */
-void VideoWidget::translate_zoom_from_preview_click(QPoint click_pos, bool pan) {
+void VideoWidget::translate_zoom_from_preview_click(QPoint click_pos) {
     update_processing_settings([&](){
         double scale_factor =  z_settings.frame_size.width() / static_cast<double>(z_settings.preview_window_size.width());
         QPoint scaled = click_pos * scale_factor;
-        if (pan){
-            z_settings.x_movement = scaled.x();
-            z_settings.y_movement = scaled.y();
-        }
-//        } else {
-//            z_settings.center = scaled;
-//            z_settings.zoom_step = 0;
-//            z_settings.do_point_zoom =true;
-//        }
+        z_settings.x_movement = scaled.x();
+        z_settings.y_movement = scaled.y();
     });
 }
 

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1649,6 +1649,28 @@ void VideoWidget::update_zoom_preview_size(QSize s) {
     });
 }
 
+/**
+ * @brief VideoWidget::translate_zoom_from_preview_click
+ * Scales the click coordinates (from zoom preview) to new coordinates in the original frame
+ * and updates the frame processor so that the viewport will center around that position.
+ * @param click_pos:    The coordinate where the click occured (zoom preview coordinates)
+ */
+void VideoWidget::translate_zoom_from_preview_click(QPoint click_pos, bool pan) {
+    update_processing_settings([&](){
+        double scale_factor =  z_settings.frame_size.width() / static_cast<double>(z_settings.preview_window_size.width());
+        QPoint scaled = click_pos * scale_factor;
+        if (pan){
+            z_settings.x_movement = scaled.x();
+            z_settings.y_movement = scaled.y();
+        }
+//        } else {
+//            z_settings.center = scaled;
+//            z_settings.zoom_step = 0;
+//            z_settings.do_point_zoom =true;
+//        }
+    });
+}
+
 void VideoWidget::speed_up_activate() {
     if (speed_slider->value() == speed_slider->maximum()) return;
     speed_slider->setValue(speed_slider->value() +1);

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -205,6 +205,7 @@ public slots:
     void update_playback_speed(int speed);
     void set_brightness_contrast(int bri, double cont, double gamma);
     void update_zoom_preview_size(QSize s);
+    void translate_zoom_from_preview_click(QPoint click_pos, bool pan);
 private:
     const QSize BTN_SIZE = QSize(30, 30);
 

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -205,7 +205,7 @@ public slots:
     void update_playback_speed(int speed);
     void set_brightness_contrast(int bri, double cont, double gamma);
     void update_zoom_preview_size(QSize s);
-    void translate_zoom_from_preview_click(QPoint click_pos, bool pan);
+    void translate_zoom_from_preview_click(QPoint click_pos);
 private:
     const QSize BTN_SIZE = QSize(30, 30);
 

--- a/ViAn/GUI/zoompreviewwidget.cpp
+++ b/ViAn/GUI/zoompreviewwidget.cpp
@@ -19,10 +19,6 @@ void ZoomPreviewWidget::center_image(const QSize &s) {
     }
 }
 
-void ZoomPreviewWidget::handle_mouse(const QPoint &pos) {
-    qDebug() << pos;
-}
-
 ZoomPreviewWidget::ZoomPreviewWidget(QWidget *parent) : QWidget(parent) {
     setMinimumSize(QSize(200,100));
 }
@@ -47,11 +43,13 @@ void ZoomPreviewWidget::resizeEvent(QResizeEvent *event) {
     emit window_size(event->size());
 }
 
+/**
+ * @brief ZoomPreviewWidget::mousePressEvent
+ * Event for when the widget is clicked
+ * @param event
+ */
 void ZoomPreviewWidget::mousePressEvent(QMouseEvent *event) {
     if (event->button() == Qt::LeftButton) {
-        panning = false;
-        emit pan_translation(event->pos(), false);
-    } else if (event->button() == Qt::RightButton) {
         panning = true;
         start_point = event->pos();
     } else {
@@ -59,11 +57,16 @@ void ZoomPreviewWidget::mousePressEvent(QMouseEvent *event) {
     }
 }
 
+/**
+ * @brief ZoomPreviewWidget::mouseMoveEvent
+ * Event for when the mouse (pressed) is dragged inside the widget
+ * @param event
+ */
 void ZoomPreviewWidget::mouseMoveEvent(QMouseEvent *event) {
     if (!panning) return;
     QPoint movement = event->pos() - start_point;
     start_point = event->pos();
-    emit pan_translation(movement, true);
+    emit pan_translation(movement);
 }
 
 /**

--- a/ViAn/GUI/zoompreviewwidget.cpp
+++ b/ViAn/GUI/zoompreviewwidget.cpp
@@ -48,11 +48,22 @@ void ZoomPreviewWidget::resizeEvent(QResizeEvent *event) {
 }
 
 void ZoomPreviewWidget::mousePressEvent(QMouseEvent *event) {
-    handle_mouse(event->pos());
+    if (event->button() == Qt::LeftButton) {
+        panning = false;
+        emit pan_translation(event->pos(), false);
+    } else if (event->button() == Qt::RightButton) {
+        panning = true;
+        start_point = event->pos();
+    } else {
+        panning = false;
+    }
 }
 
 void ZoomPreviewWidget::mouseMoveEvent(QMouseEvent *event) {
-    handle_mouse(event->pos());
+    if (!panning) return;
+    QPoint movement = event->pos() - start_point;
+    start_point = event->pos();
+    emit pan_translation(movement, true);
 }
 
 /**

--- a/ViAn/GUI/zoompreviewwidget.cpp
+++ b/ViAn/GUI/zoompreviewwidget.cpp
@@ -19,6 +19,10 @@ void ZoomPreviewWidget::center_image(const QSize &s) {
     }
 }
 
+void ZoomPreviewWidget::handle_mouse(const QPoint &pos) {
+    qDebug() << pos;
+}
+
 ZoomPreviewWidget::ZoomPreviewWidget(QWidget *parent) : QWidget(parent) {
     setMinimumSize(QSize(200,100));
 }
@@ -41,6 +45,14 @@ void ZoomPreviewWidget::paintEvent(QPaintEvent *event) {
  */
 void ZoomPreviewWidget::resizeEvent(QResizeEvent *event) {
     emit window_size(event->size());
+}
+
+void ZoomPreviewWidget::mousePressEvent(QMouseEvent *event) {
+    handle_mouse(event->pos());
+}
+
+void ZoomPreviewWidget::mouseMoveEvent(QMouseEvent *event) {
+    handle_mouse(event->pos());
 }
 
 /**

--- a/ViAn/GUI/zoompreviewwidget.h
+++ b/ViAn/GUI/zoompreviewwidget.h
@@ -13,9 +13,12 @@ private:
     cv::Mat _tmp;
     QImage _qimage;
     QPoint anchor{0, 0};
+    QPoint start_point{0,0};
 
+    bool panning{false};
     bool center_along_xy{false}; // If false the image will only be centered along the x-axis
     void center_image(const QSize& s);
+    void handle_mouse(const QPoint& pos);
 
 public:
     explicit ZoomPreviewWidget(QWidget *parent = nullptr);
@@ -28,6 +31,8 @@ protected:
 
 signals:
     void window_size(QSize s);
+    void pan_translation(QPoint pos, bool pan);
+    void new_center(QPoint pos);
 
 public slots:
     void frame_update(cv::Mat frame);

--- a/ViAn/GUI/zoompreviewwidget.h
+++ b/ViAn/GUI/zoompreviewwidget.h
@@ -15,7 +15,6 @@ private:
     QPoint anchor{0, 0};
 
     bool center_along_xy{false}; // If false the image will only be centered along the x-axis
-
     void center_image(const QSize& s);
 
 public:
@@ -24,6 +23,8 @@ public:
 protected:
     void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent * event) override;
 
 signals:
     void window_size(QSize s);

--- a/ViAn/GUI/zoompreviewwidget.h
+++ b/ViAn/GUI/zoompreviewwidget.h
@@ -18,7 +18,6 @@ private:
     bool panning{false};
     bool center_along_xy{false}; // If false the image will only be centered along the x-axis
     void center_image(const QSize& s);
-    void handle_mouse(const QPoint& pos);
 
 public:
     explicit ZoomPreviewWidget(QWidget *parent = nullptr);
@@ -31,8 +30,7 @@ protected:
 
 signals:
     void window_size(QSize s);
-    void pan_translation(QPoint pos, bool pan);
-    void new_center(QPoint pos);
+    void pan_translation(QPoint pos);
 
 public slots:
     void frame_update(cv::Mat frame);

--- a/ViAn/Video/frameprocessor.cpp
+++ b/ViAn/Video/frameprocessor.cpp
@@ -166,6 +166,7 @@ void FrameProcessor::process_frame() {
         qWarning() << "Failed to copy new frame in processor";
         return;
     }
+    m_z_settings->frame_size = QSize(m_frame.cols, m_frame.rows);
 
     // Rotates the frame, according to the choosen direction.
     // TODO: Computation heavy.. Will cause lag on larger images.
@@ -203,6 +204,7 @@ void FrameProcessor::process_frame() {
     m_manipulator.apply(manipulated_frame);
 
     // Emit manipulated frame and current frame number
+    m_z_settings->center = m_zoomer.get_center();
     emit zoom_preview(preview_frame);
     emit done_processing(m_frame, manipulated_frame, m_frame_index->load());
 }

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -28,6 +28,7 @@ struct zoomer_settings {
 
     QSize draw_area_size = QSize(100,100);
     QSize preview_window_size = QSize(100, 50);
+    QSize frame_size = QSize(100, 100);
 
     QPoint zoom_area_tl = QPoint(0,0);
     QPoint zoom_area_br = QPoint(100,100);

--- a/ViAn/Video/zoomer.cpp
+++ b/ViAn/Video/zoomer.cpp
@@ -206,6 +206,8 @@ void Zoomer::point_zoom(QPoint original_point, double zoom_step) {
     double dx = (original_point.x() - m_viewport.center.x) * (zoom_step - 1);
     double dy = (original_point.y() - m_viewport.center.y) * (zoom_step - 1);
 
+
+
     // Translate center
     m_viewport = cv::RotatedRect(cv::Point2f(m_viewport.center.x + dx, m_viewport.center.y + dy),
                                  m_viewport.size,


### PR DESCRIPTION
Added panning functionality to the zoom preview widget. The action is bound to the left mouse buttom.
Closes #123 