### PR TITLE
Video item removal fix

### DIFF
--- a/ViAn/GUI/framewidget.cpp
+++ b/ViAn/GUI/framewidget.cpp
@@ -382,7 +382,7 @@ void FrameWidget::paintEvent(QPaintEvent *event) {
     }
     // TODO This is to prevent crash when clicking bookmark before loading video
     // This should get a better fix later
-    if (!m_vid_proj) {
+    if (!m_vid_proj || !m_vid_proj->get_overlay()) {
         painter.end();
         return;
     }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -595,6 +595,7 @@ void ProjectWidget::insert_to_path_index(VideoProject *vid_proj) {
                 v_item->load_sequence_items();
             }
         }
+        setCurrentItem(item);
     }
 }
 

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1295,7 +1295,8 @@ void ProjectWidget::remove_video_item(QTreeWidgetItem *item) {
             removed_sequences.push_back(v_proj);
         } else {
             auto video_it = std::find(video_list.begin(), video_list.end(), (*it)->get_video());
-            video_list.erase(video_it);
+            if (video_it != video_list.end())
+                video_list.erase(video_it);
             delete v_proj;
         }
         m_proj->set_unsaved(true);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -457,6 +457,8 @@ void ProjectWidget::tree_add_video(VideoProject* vid_proj, const QString& vid_na
     emit set_status_bar("Video added: " + vid_name);
     // Add analysis and tag
     add_analyses_to_item(vid_item);
+
+    setCurrentItem(vid_item);
 }
 
 /**

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -757,7 +757,6 @@ void VideoWidget::delete_interval() {
     m_interval.first = -1;
     m_interval.second = -1;
     playback_slider->clear_interval();
-    playback_slider->update();
 }
 
 /**


### PR DESCRIPTION
Fix bug that caused a crash to sometimes occur when removing multiple video items from the project tree. Fixes #206 