### PR TITLE
New diff seq

### DIFF
--- a/ViAn/Analysis/analysissettings.cpp
+++ b/ViAn/Analysis/analysissettings.cpp
@@ -2,7 +2,7 @@
 
 #include "constants.h"
 
-AnalysisSettings::AnalysisSettings(ANALYSIS_TYPE type,
+AnalysisSettings::AnalysisSettings(int type,
                                    std::pair<int, int> interval,
                                    cv::Rect bounding_box)
     : type(type)
@@ -11,7 +11,7 @@ AnalysisSettings::AnalysisSettings(ANALYSIS_TYPE type,
     set_bounding_box(bounding_box);
 }
 
-AnalysisSettings::AnalysisSettings(ANALYSIS_TYPE type) : type(type) {
+AnalysisSettings::AnalysisSettings(int type) : type(type) {
     reset_settings();
 }
 
@@ -107,7 +107,7 @@ void AnalysisSettings::set_bounding_box(const cv::Rect &value) {
     use_bounding_box = true;
 }
 
-ANALYSIS_TYPE AnalysisSettings::get_type() const {
+int AnalysisSettings::get_type() const {
     return type;
 }
 

--- a/ViAn/Analysis/analysissettings.h
+++ b/ViAn/Analysis/analysissettings.h
@@ -19,15 +19,15 @@ class AnalysisSettings {
     SettingsDescr m_descriptions;       // Descriptions for settings constants
 
 public:
-    ANALYSIS_TYPE type;
+    int type;
     cv::Rect bounding_box;
     std::pair<int, int> interval;
     bool use_bounding_box = false;
     bool use_interval = false;
     bool quick_analysis = false;
 
-    AnalysisSettings(ANALYSIS_TYPE type, std::pair<int, int> interval, cv::Rect bounding_box);
-    AnalysisSettings(ANALYSIS_TYPE type);
+    AnalysisSettings(int type, std::pair<int, int> interval, cv::Rect bounding_box);
+    AnalysisSettings(int type);
     AnalysisSettings();
     AnalysisSettings(AnalysisSettings *as);
     virtual ~AnalysisSettings();
@@ -35,7 +35,7 @@ public:
     void reset_settings();
     cv::Rect get_bounding_box() const;
     void set_bounding_box(const cv::Rect &value);
-    ANALYSIS_TYPE get_type() const;
+    int get_type() const;
     std::pair<int, int> get_interval() const;
     void set_interval(const std::pair<int, int> &value);
 

--- a/ViAn/GUI/Analysis/analysisslider.cpp
+++ b/ViAn/GUI/Analysis/analysisslider.cpp
@@ -164,6 +164,7 @@ void AnalysisSlider::set_basic_analysis(BasicAnalysis* analysis) {
         switch (analysis->get_type()) {
         case TAG:
         case DRAWING_TAG:
+        case SEQUENCE_TAG:
             m_tag = dynamic_cast<Tag*>(analysis);
             repaint();
             break;
@@ -267,7 +268,6 @@ int AnalysisSlider::get_next_poi_start(int curr_frame) {
             }
         }
     }
-
     return curr_frame;
 }
 

--- a/ViAn/GUI/TreeItems/tagframeitem.cpp
+++ b/ViAn/GUI/TreeItems/tagframeitem.cpp
@@ -1,16 +1,13 @@
 #include "tagframeitem.h"
 
 #include "Project/Analysis/tagframe.h"
-#include "tagitem.h"
 
-TagFrameItem::TagFrameItem(int frame) : TreeItem(TAG_FRAME_ITEM) {
-    m_frame = frame;
-    setText(0, QString::number(m_frame));
-    setFlags(flags() & ~Qt::ItemIsEditable);
-}
-
-void TagFrameItem::set_state(TagFrame* t_frame) {
+TagFrameItem::TagFrameItem(TagFrame* t_frame) : TreeItem(TAG_FRAME_ITEM) {
     m_t_frame = t_frame;
+    m_frame = t_frame->m_frame;
+    m_name = t_frame->name;
+    setText(0, m_name);
+    setFlags(flags() & ~Qt::ItemIsEditable);
 }
 
 VideoState TagFrameItem::get_state() {

--- a/ViAn/GUI/TreeItems/tagframeitem.h
+++ b/ViAn/GUI/TreeItems/tagframeitem.h
@@ -7,10 +7,11 @@
 class TagFrame;
 class TagFrameItem : public TreeItem {
     int m_frame;
+    QString m_name;
     TagFrame* m_t_frame = nullptr;
 public:
     TagFrameItem(int frame);
-    void set_state(TagFrame *t_frame);
+    TagFrameItem(TagFrame *t_frame);
     VideoState get_state();
     int get_frame();
     void remove();

--- a/ViAn/GUI/TreeItems/videoitem.cpp
+++ b/ViAn/GUI/TreeItems/videoitem.cpp
@@ -12,8 +12,6 @@
 
 #include <QTreeWidgetItem>
 
-//const QString VideoItem::SEQUENCE_CONTAINER_NAME = "Image";
-
 VideoItem::VideoItem(VideoProject* video_project): TreeItem(VIDEO_ITEM) {
     m_vid_proj = video_project;
     setFlags(flags() | Qt::ItemIsDragEnabled);
@@ -85,7 +83,7 @@ void VideoItem::load_thumbnail() {
 void VideoItem::load_sequence_items() {
     if (m_vid_proj == nullptr ) return;
     auto seq = dynamic_cast<ImageSequence*>(m_vid_proj->get_video());
-    if (seq) {
+    if (seq && seq->get_sequence_type() == VIDEO_SEQUENCE) {
         // Create container item for all SequenceItems
         SequenceContainerItem* container = new SequenceContainerItem();
         addChild(container);
@@ -104,15 +102,14 @@ void VideoItem::load_sequence_items() {
                 bool added{false};
                 for (auto i = 0; i < container->childCount(); ++i) {
                     auto child_item = dynamic_cast<SequenceItem*>(container->child(i));
-                    if (child_item) {
-                        if (child_item->get_index() > seq_item_index) {
-                            container->insertChild(i, seq_item);
-                            added = true;
-                            break;
-                        }
+                    if (!child_item) {
+                        continue;
+                    } else if (child_item->get_index() > seq_item_index) {
+                        container->insertChild(i, seq_item);
+                        added = true;
+                        break;
                     }
                 }
-
                 if (!added) {
                     // Item should be added at the end
                     container->addChild(seq_item);

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -241,6 +241,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     connect(project_wgt, &ProjectWidget::set_show_analysis_details, video_wgt->playback_slider, &AnalysisSlider::set_show_ana_interval);
     connect(project_wgt, &ProjectWidget::set_detections, video_wgt->frame_wgt, &FrameWidget::set_detections);
     connect(project_wgt, &ProjectWidget::enable_poi_btns, video_wgt, &VideoWidget::enable_poi_btns);
+    connect(project_wgt, &ProjectWidget::seq_tag_btns, video_wgt, &VideoWidget::set_seq_tag_btns);
     connect(project_wgt, &ProjectWidget::set_poi_slider, video_wgt->playback_slider, &AnalysisSlider::set_show_pois);
     connect(project_wgt, &ProjectWidget::set_tag_slider, video_wgt->playback_slider, &AnalysisSlider::set_show_tags);
     connect(project_wgt, &ProjectWidget::set_interval_slider, video_wgt->playback_slider, &AnalysisSlider::set_show_interval_areas);

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -638,8 +638,10 @@ void ProjectWidget::save_item_data(QTreeWidgetItem* item) {
             save_item_data(child);
         } else if (child->type() == FOLDER_ITEM) {
             save_item_data(child);
-        } else if (child->type() == TAG_ITEM ||
-                   child->type() == ANALYSIS_ITEM ||
+        } else if (child->type() == TAG_ITEM) {
+            TagItem* t_item = dynamic_cast<TagItem*>(child);
+            t_item->rename();
+        } else if (child->type() == ANALYSIS_ITEM ||
                    child->type() == DRAWING_TAG_ITEM ||
                    child->type() == INTERVAL_ITEM) {
             auto r_item = dynamic_cast<TreeItem*>(child);
@@ -1139,7 +1141,7 @@ void ProjectWidget::context_menu(const QPoint &point) {
             TagItem* t_item = dynamic_cast<TagItem*>(item->parent());
             Tag* tag = t_item->get_tag();
             if (tag->get_type() == SEQUENCE_TAG) {
-                menu.addAction("Delete", this, &ProjectWidget::remove_item);
+                //menu.addAction("Delete", this, &ProjectWidget::remove_item);
                 break;
             }
             menu.addAction("Update", this, &ProjectWidget::update_tag);
@@ -1404,7 +1406,29 @@ void ProjectWidget::remove_tag_frame_item(QTreeWidgetItem *item) {
 //            if (sequence) {
 //                sequence->remove_image_with_index(frame);
 //            }
+
+
+//            //tag->remove_frame(frame);
+
+//            // update the state in the tag_frames with new index (-1)
+//            // make the state that the tagframes hold into pointers
+//            // so i can update them from the tag_map in the tag.
+
+//            // Otherwise i would have to iterate through the proj tree and update
+//            // the states from there or close and remake them.
+
+//            tag->update_index_tag(frame);
+//            tag->remove_frame(tag->tag_map.rbegin()->first);
+//            tree_item_changed(item->parent()->parent());
+
+//            // Remove frame and update the index of all other tags
+//            //tag->update_index_tag(frame);
+//            //emit marked_basic_analysis(tag);
+//            // tag seq not work, normal do
+//            // different when saved and not
 //        }
+//    } else {
+//        tag->remove_frame(frame);   // untag
     }
 }
 

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -456,6 +456,7 @@ void ProjectWidget::tree_add_video(VideoProject* vid_proj, const QString& vid_na
                 // Create the tagframe
                 VideoState state;
                 state.frame = frame;
+                state.scale_factor = 1.;
                 TagFrame* t_frame = new TagFrame(frame, state);
                 t_frame->set_name(Utility::name_from_path(path));
                 tag->add_frame(frame, t_frame);
@@ -777,6 +778,7 @@ bool ProjectWidget::prompt_save() {
  * @param prev_item     : previous tree item
  */
 void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* prev_item) {
+    qDebug() << "------------- Clicked";
     Q_UNUSED(prev_item)
     if (!item) return;
     switch(item->type()){
@@ -917,10 +919,10 @@ void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* pr
 
         VideoState state;
         state = tf_item->get_state();
-        if (item->parent()->type() == TAG_ITEM) {
-            emit marked_video_state(vid_item->get_video_project(), state);
-            emit item_type(item->type());
+        emit marked_video_state(vid_item->get_video_project(), state);
+        emit item_type(item->type());
 
+        if (item->parent()->type() == TAG_ITEM) {
             TagItem* tag_item = dynamic_cast<TagItem*>(item->parent());
             emit marked_basic_analysis(tag_item->get_tag());
 
@@ -928,10 +930,9 @@ void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* pr
             tag_item->setCheckState(0, Qt::Checked);
             m_tag_item = tag_item;
         } else if (item->parent()->type() == DRAWING_TAG_ITEM) {
-            emit marked_video_state(vid_item->get_video_project(), state);
-            emit item_type(item->type());
             DrawingTagItem* dt_item = dynamic_cast<DrawingTagItem*>(item->parent());
             emit marked_basic_analysis(dt_item->get_tag());
+
             if (m_tag_item) m_tag_item->setCheckState(0, Qt::Unchecked);
             m_tag_item = nullptr;
         }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -454,7 +454,7 @@ void ProjectWidget::tree_add_video(VideoProject* vid_proj, const QString& vid_na
                 int frame = sequence->get_index_of_hash(hash);
 
                 // Create the tagframe
-                VideoState state; // = sequence->state;
+                VideoState state;
                 state.frame = frame;
                 TagFrame* t_frame = new TagFrame(frame, state);
                 t_frame->set_name(Utility::name_from_path(path));

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -83,7 +83,7 @@ public slots:
     void add_video();
     void create_video(QString path);
     void add_images();
-    void create_sequence(QStringList image_paths, QStringList checksums, QString path);
+    void create_sequence(QStringList image_paths, QStringList checksums, QString path, int seq_type);
     void start_analysis(VideoProject*, AnalysisSettings*settings = nullptr);
     void add_tag(VideoProject*, Tag *tag);
     void add_frames_to_tag_item(TreeItem *item);

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -63,6 +63,7 @@ signals:
     void set_show_analysis_details(bool);
     void set_detections(bool);
     void enable_poi_btns(bool, bool);
+    void seq_tag_btns(bool);
     void set_poi_slider(bool);
     void set_tag_slider(bool);
     void set_interval_slider(bool);

--- a/ViAn/GUI/sequencedialog.cpp
+++ b/ViAn/GUI/sequencedialog.cpp
@@ -1,0 +1,71 @@
+#include "sequencedialog.h"
+
+#include <QBoxLayout>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+
+SequenceDialog::SequenceDialog(QString* name, int *type, QWidget* parent) : QDialog(parent) {
+    setWindowTitle(tr("Vian - Import image sequence"));
+    setAttribute(Qt::WA_DeleteOnClose);
+    // Remove the question mark from the title bar
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    m_name = name;
+    m_type = type;
+
+    // Setup widget layout
+    QVBoxLayout* vertical_layout = new QVBoxLayout;
+    name_text = new QLineEdit(this);
+    name_text->setText("Sequence");
+    video_type = new QRadioButton;
+    video_type->setText("Video");
+    video_type->setChecked(true);
+    tag_type = new QRadioButton;
+    tag_type->setText("Tag");
+
+    btn_box = new QDialogButtonBox(Qt::Horizontal);
+    btn_box->addButton(QDialogButtonBox::Ok);
+    btn_box->addButton(QDialogButtonBox::Cancel);
+
+    QFormLayout* sequence_name_layout = new QFormLayout;
+    sequence_name_layout->addRow("Sequence name:", name_text);
+
+    QVBoxLayout* type_btns = new QVBoxLayout;
+    type_btns->addWidget(video_type);
+    type_btns->addWidget(tag_type);
+
+    QFormLayout* sequence_type_layout = new QFormLayout;
+    sequence_type_layout->addRow("Open images as: ", type_btns);
+
+    vertical_layout->addLayout(sequence_name_layout);
+    vertical_layout->addLayout(sequence_type_layout);
+    vertical_layout->addWidget(btn_box);
+    setLayout(vertical_layout);
+
+    connect(btn_box->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, &SequenceDialog::ok_btn_clicked);
+    connect(btn_box->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &SequenceDialog::cancel_btn_clicked);
+}
+
+SequenceDialog::~SequenceDialog() {
+    delete name_text;
+    delete btn_box;
+    delete video_type;
+    delete tag_type;
+}
+
+void SequenceDialog::ok_btn_clicked() {
+    *m_name = name_text->text();
+    if (video_type->isChecked()) {
+        *m_type = 1;
+    } else if (tag_type->isChecked()) {
+        *m_type = 2;
+    }
+    accept();
+}
+
+void SequenceDialog::cancel_btn_clicked() {
+    reject();
+}

--- a/ViAn/GUI/sequencedialog.h
+++ b/ViAn/GUI/sequencedialog.h
@@ -1,0 +1,29 @@
+#ifndef SEQUENCEDIALOG_H
+#define SEQUENCEDIALOG_H
+
+#include <QDialog>
+
+
+class QDialogButtonBox;
+class QLineEdit;
+class QRadioButton;
+class SequenceDialog : public QDialog
+{
+    Q_OBJECT
+    QString* m_name;        // Name of sequence
+    int* m_type;           // Type of sequence, 0 = video, 1 = tag
+    QLineEdit* name_text;
+    QDialogButtonBox* btn_box;
+
+    QRadioButton* video_type;
+    QRadioButton* tag_type;
+public:
+    explicit SequenceDialog(QString* name, int* type, QWidget* parent = nullptr);
+    ~SequenceDialog();
+
+ private slots:
+    void ok_btn_clicked();
+    void cancel_btn_clicked();
+};
+
+#endif // SEQUENCEDIALOG_H

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -664,6 +664,12 @@ void VideoWidget::set_zoom_state(QPoint center, double scale, int angle) {
             m_vid_proj->state.scale_factor = scale;
             m_vid_proj->state.rotation = angle;
         }
+        if (m_vid_proj->get_video()->get_sequence_type() == TAG_SEQUENCE) {
+            TagFrame* t_frame = m_tag->tag_map.at(frame_index.load());
+            t_frame->m_state.center = center;
+            t_frame->m_state.scale_factor = scale;
+            t_frame->m_state.rotation = angle;
+        }
         Video* video = m_vid_proj->get_video();
         video->state.center = center;
         video->state.scale_factor = scale;

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -186,8 +186,10 @@ void VideoWidget::init_video_controller(){
  * Creates a new FrameProcessor instance which is then moved to a new thread.
  */
 void VideoWidget::init_frame_processor() {
-    f_processor = new FrameProcessor(&new_frame, &settings_changed, &z_settings, &video_width,
-                                     &video_height, &new_frame_video, &m_settings, &v_sync, &frame_index, &o_settings, &overlay_changed, &m_abort_processor);
+    f_processor = new FrameProcessor(&new_frame, &settings_changed, &z_settings,
+                                     &video_width, &video_height, &new_frame_video,
+                                     &m_settings, &v_sync, &frame_index, &o_settings,
+                                     &overlay_changed, &m_abort_processor);
 
     try {
         processing_thread = new QThread(this);
@@ -196,6 +198,7 @@ void VideoWidget::init_frame_processor() {
         connect(processing_thread, &QThread::started, f_processor, &FrameProcessor::check_events);
         connect(f_processor, &FrameProcessor::done_processing, frame_wgt, &FrameWidget::on_new_image);
         connect(f_processor, &FrameProcessor::zoom_preview, this, &VideoWidget::zoom_preview);
+        connect(f_processor, &FrameProcessor::new_frame_size, this, &VideoWidget::set_frame_size);
 
         connect(frame_wgt, &FrameWidget::zoom_points, this, &VideoWidget::set_zoom_area);
         connect(scroll_area, &DrawScrollArea::new_size, this, &VideoWidget::set_draw_area_size);
@@ -1236,11 +1239,10 @@ void VideoWidget::capture_failed() {
 void VideoWidget::on_video_info(int video_width, int video_height, int frame_rate, int last_frame){
     int current_frame_index = frame_index.load();
     m_vid_proj->get_video()->set_size(video_width, video_height);
-    m_video_width = video_width;
-    m_video_height = video_height;
     m_frame_rate = frame_rate;
     m_frame_length = last_frame + 1;
     current_frame_size = QSize(video_width, video_height);
+    set_frame_size(video_width, video_height);
 
     // Solves a bug where the setMaximum will set the frame index to max in some cases
     playback_slider->blockSignals(true);
@@ -1256,10 +1258,15 @@ void VideoWidget::on_video_info(int video_width, int video_height, int frame_rat
         set_current_time(0);
     }
     fps_label->setText(QString::number(frame_rate) + "fps");
-    size_label->setText("(" + QString::number(video_width) + "x" + QString::number(video_height) + ")");
     max_frames->setText("/ " + QString::number(last_frame));
 
     on_new_frame();
+}
+
+void VideoWidget::set_frame_size(int width, int height) {
+    m_video_width = width;
+    m_video_height = height;
+    size_label->setText("(" + QString::number(width) + "x" + QString::number(height) + ")");
 }
 
 void VideoWidget::on_playback_stopped(){

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1512,6 +1512,9 @@ void VideoWidget::set_state(VideoState state) {
         z_settings.center = state.center;
         z_settings.zoom_factor = state.scale_factor;
         z_settings.rotation = state.rotation;
+        // TODO Maybe test some more to see if this really isn't needed anymore
+        // Now with the new flag variable in the frameprocessor it shouldn't be needed
+        // It it's removed, remove the check from the processor as well
         //z_settings.skip_frame_refresh = frame_index.load() != state.frame;
         m_settings.brightness = state.brightness;
         m_settings.contrast = state.contrast;

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -171,6 +171,7 @@ public slots:
     void enable_poi_btns(bool, bool);
     void capture_failed();
     void on_video_info(int video_width, int video_height, int frame_rate, int last_frame);
+    void set_frame_size(int width, int height);
     void on_playback_stopped(void);
 
     void set_overlay_removed();

--- a/ViAn/GUI/videowidget.h
+++ b/ViAn/GUI/videowidget.h
@@ -75,6 +75,7 @@ private:
     std::atomic_bool video_loaded{false};       // True when a video is loaded/open
     std::atomic_bool m_abort_playback{false};     // Flag used to abort playback when closing program
     std::atomic_bool m_abort_processor{false};
+    std::atomic_bool m_frame_changing{false};   // True when a new frame is to be loaded but have yet bet set in the processor/zoomer
 
     std::condition_variable player_con;         // Used to notify the video player when to load a new video or when to play the current one
     std::mutex player_lock;
@@ -169,6 +170,7 @@ public slots:
     void frame_line_edit_finished();
     void zoom_label_finished();
     void enable_poi_btns(bool, bool);
+    void set_seq_tag_btns(bool);
     void capture_failed();
     void on_video_info(int video_width, int video_height, int frame_rate, int last_frame);
     void set_frame_size(int width, int height);

--- a/ViAn/Project/Analysis/analysis.cpp
+++ b/ViAn/Project/Analysis/analysis.cpp
@@ -35,7 +35,7 @@ void Analysis::read(const QJsonObject &json){
     settings = new_settings;
 
 
-    this->type = static_cast<ANALYSIS_TYPE>(json["type"].toInt());
+    this->type = json["type"].toInt();
     this->m_name = json["name"].toString();
     QJsonArray json_pois = json["POI:s"].toArray();
     for (int i = 0; i < json_pois.size(); ++i) {
@@ -72,7 +72,7 @@ void Analysis::write(QJsonObject &json){
     m_unsaved_changes = false;
 }
 
-ANALYSIS_TYPE Analysis::get_type() const {
+int Analysis::get_type() const {
     return type;
 }
 

--- a/ViAn/Project/Analysis/analysis.h
+++ b/ViAn/Project/Analysis/analysis.h
@@ -14,12 +14,12 @@
 class Analysis : public BasicAnalysis {
     friend class AnalysisProxy;
 public:
-    ANALYSIS_TYPE type;
+    int type;
 public:
     ~Analysis() override;
     virtual void read(const QJsonObject& json) override;
     virtual void write(QJsonObject& json) override;
-    virtual ANALYSIS_TYPE get_type() const override;
+    virtual int get_type() const override;
     std::vector<cv::Rect> get_detections_on_frame(int frame_num);
     QString get_name() const;
 

--- a/ViAn/Project/Analysis/analysisproxy.cpp
+++ b/ViAn/Project/Analysis/analysisproxy.cpp
@@ -119,7 +119,7 @@ void AnalysisProxy::write(QJsonObject &json) {
     m_unsaved_changes = false;
 }
 
-ANALYSIS_TYPE AnalysisProxy::get_type() const {
+int AnalysisProxy::get_type() const {
     return type;
 }
 

--- a/ViAn/Project/Analysis/analysisproxy.h
+++ b/ViAn/Project/Analysis/analysisproxy.h
@@ -17,7 +17,7 @@ class AnalsysSettings;
 class AnalysisProxy : public BasicAnalysis
 {
     QString file_analysis = "";  // m_analysis.full_path()
-    ANALYSIS_TYPE type = MOTION_DETECTION; //TODO Remove
+    int type = MOTION_DETECTION;
 public:
     AnalysisProxy();
     AnalysisProxy(const QString file_analysis);
@@ -32,7 +32,7 @@ public:
     AnalysisSettings *get_settings();
 
     void reset_root_dir(const QString &dir);
-    virtual ANALYSIS_TYPE get_type() const override;
+    virtual int get_type() const override;
     virtual QString full_path() const override;
     virtual void read(const QJsonObject& json) override;
     virtual void write(QJsonObject& json) override;

--- a/ViAn/Project/Analysis/basicanalysis.cpp
+++ b/ViAn/Project/Analysis/basicanalysis.cpp
@@ -29,7 +29,7 @@ void BasicAnalysis::clear_intervals() {
     m_intervals.clear();
 }
 
-ANALYSIS_TYPE BasicAnalysis::get_type() const {
+int BasicAnalysis::get_type() const {
     return BASIC_ANALYSIS;
 }
 

--- a/ViAn/Project/Analysis/basicanalysis.h
+++ b/ViAn/Project/Analysis/basicanalysis.h
@@ -13,7 +13,8 @@
 
 class AnalysisSettings;
 
-enum ANALYSIS_TYPE {MOTION_DETECTION = 1, TAG = 2, BASIC_ANALYSIS = 3, DRAWING_TAG = 4, INTERVAL = 5};
+enum ANALYSIS_TYPE {MOTION_DETECTION = 1, TAG, BASIC_ANALYSIS, DRAWING_TAG, INTERVAL,
+                    SEQUENCE_TAG};
 
 struct interval_cmp {
     bool operator()(const AnalysisInterval* lhs, const AnalysisInterval* rhs) const {
@@ -45,7 +46,7 @@ public:
     virtual void read(const QJsonObject& json);
     virtual void write(QJsonObject& json);
     virtual void add_interval(AnalysisInterval *ai);
-    virtual ANALYSIS_TYPE get_type() const;
+    virtual int get_type() const;
 
     ID get_id();
     void set_id(ID id);

--- a/ViAn/Project/Analysis/interval.cpp
+++ b/ViAn/Project/Analysis/interval.cpp
@@ -116,7 +116,7 @@ bool Interval::does_overlap(std::pair<int, int> a, std::pair<int, int> b) {
     return (std::min(a.second, b.second) >= std::max(a.first, b.first));
 }
 
-ANALYSIS_TYPE Interval::get_type() const {
+int Interval::get_type() const {
     return INTERVAL;
 }
 

--- a/ViAn/Project/Analysis/interval.h
+++ b/ViAn/Project/Analysis/interval.h
@@ -12,7 +12,7 @@ class Interval : public BasicAnalysis
 public:
     Interval(QString name = "");
     ~Interval() override;
-    virtual ANALYSIS_TYPE get_type() const override;
+    virtual int get_type() const override;
     virtual void read(const QJsonObject& json) override;
     virtual void write(QJsonObject& json) override;
 

--- a/ViAn/Project/Analysis/tag.cpp
+++ b/ViAn/Project/Analysis/tag.cpp
@@ -2,7 +2,10 @@
 
 #include "tagframe.h"
 
+#include <QDebug>
 #include <QJsonArray>
+
+#include <map>
 
 Tag::Tag(QString name, int type) {
     m_name = name;
@@ -60,6 +63,36 @@ void Tag::update_color_whole_tag(int b, double c, double g) {
         (*it).second->m_state.brightness = b;
         (*it).second->m_state.contrast = c;
         (*it).second->m_state.gamma = g;
+    }
+}
+
+/**
+ * @brief Tag::update_index_tag
+ * Update the tag so all tag frames' index matches the files index.
+ * Use after changing a frame of a tag_sequence
+ */
+void Tag::update_index_tag(int frame) {
+    qDebug() << "frame" << frame;
+    if (m_type != SEQUENCE_TAG) return;
+    TagFrame* temp_frame = nullptr;
+    for (auto it = tag_map.rbegin(); it != tag_map.rend(); ++it) {
+
+
+        if (it->first >= frame) {
+            if (temp_frame) {
+                auto temp = it->second;
+                it->second = temp_frame;
+                temp_frame = temp;
+                it->second->m_state.frame--;// = it->second->m_state->frame-1;
+            } else {
+                temp_frame = it->second;
+            }
+
+            qDebug() << "first" << it->first <<  it->second->m_state.frame;
+        }
+        if (it->first == frame) {
+            tag_map.rbegin()->second = temp_frame;
+        }
     }
 }
 

--- a/ViAn/Project/Analysis/tag.cpp
+++ b/ViAn/Project/Analysis/tag.cpp
@@ -4,9 +4,9 @@
 
 #include <QJsonArray>
 
-Tag::Tag(QString name, bool drawing_tag) {
+Tag::Tag(QString name, int type) {
     m_name = name;
-    m_drawing_tag = drawing_tag;
+    m_type = type;
 }
 
 Tag::~Tag() {
@@ -92,21 +92,16 @@ std::vector<int> Tag::get_frames() {
 }
 
 bool Tag::is_drawing_tag() {
-    return m_drawing_tag;
+    return (m_type == DRAWING_TAG);
 }
 
-void Tag::set_drawing_tag(bool value) {
-    m_drawing_tag = value;
-}
-
-ANALYSIS_TYPE Tag::get_type() const {
-    if (m_drawing_tag) return DRAWING_TAG;
-    return TAG;
+int Tag::get_type() const {
+    return m_type;
 }
 
 void Tag::write(QJsonObject &json) {
     json["name"] = m_name;
-    json["drawing_tag"] = m_drawing_tag;
+    json["type"] = m_type;
     QJsonArray frames;
     for (auto tag_frame : tag_map) {
         QJsonObject f_num;
@@ -119,13 +114,14 @@ void Tag::write(QJsonObject &json) {
 
 void Tag::read(const QJsonObject &json) {
     m_name = json["name"].toString();
-    m_drawing_tag = json["drawing_tag"].toBool();
+    m_type = json["type"].toInt();
     QJsonArray json_intervals = json["frames"].toArray();
     for (int i = 0; i < json_intervals.size(); ++i) {
         QJsonObject json_frame = json_intervals[i].toObject();
         int frame = json_frame["frame"].toInt();
         TagFrame* t_frame = new TagFrame(frame);
         t_frame->read(json_frame);
+
         tag_map.insert(std::pair<int,TagFrame*>(frame, t_frame));
     }
     m_unsaved_changes = false;

--- a/ViAn/Project/Analysis/tag.h
+++ b/ViAn/Project/Analysis/tag.h
@@ -24,6 +24,7 @@ public:
     void remove_frame(int);
     void update_color_correction(int frame, int b_value, double c_value, double g_value);
     void update_color_whole_tag(int b, double c, double g);
+    void update_index_tag(int frame = 0);
     int next_frame(int);
     int previous_frame(int);
     std::vector<int> get_frames();

--- a/ViAn/Project/Analysis/tag.h
+++ b/ViAn/Project/Analysis/tag.h
@@ -11,12 +11,12 @@
 class TagFrame;
 
 class Tag : public BasicAnalysis {
-    bool m_drawing_tag = false;
+    int m_type = TAG;
 
 public:
-    Tag(QString name = "", bool drawing_tag = false);
+    Tag(QString name = "", int type = TAG);
     ~Tag() override;
-    virtual ANALYSIS_TYPE get_type() const override;
+    virtual int get_type() const override;
     virtual void read(const QJsonObject& json) override;
     virtual void write(QJsonObject &json) override;
     void add_frame(int frame, TagFrame *t_frame);
@@ -28,7 +28,6 @@ public:
     int previous_frame(int);
     std::vector<int> get_frames();
     bool is_drawing_tag();
-    void set_drawing_tag(bool);
 
     std::map<int, TagFrame*> tag_map;
 };

--- a/ViAn/Project/Analysis/tagframe.cpp
+++ b/ViAn/Project/Analysis/tagframe.cpp
@@ -31,10 +31,13 @@ void TagFrame::read(const QJsonObject &json) {
     QJsonObject json_state = json["state"].toObject();
     state.read(json_state);
     m_state = state;
+    name = json["name"].toString();
 }
 
 void TagFrame::write(QJsonObject &json) {
     QJsonObject json_state;
     m_state.write(json_state);
     json["state"] = json_state;
+    json["frame"] = m_state.frame;
+    json["name"] = name;
 }

--- a/ViAn/Project/Analysis/tagframe.cpp
+++ b/ViAn/Project/Analysis/tagframe.cpp
@@ -3,11 +3,13 @@
 
 TagFrame::TagFrame(int frame) {
     m_frame = frame;
+    name = QString::number(frame);
 }
 
 TagFrame::TagFrame(int frame, VideoState state) {
     m_frame = frame;
     m_state = state;
+    name = QString::number(frame);
 }
 
 TagFrame::~TagFrame() {
@@ -18,6 +20,10 @@ void TagFrame::update_color_correction(int b, double c, double g) {
     m_state.brightness = b;
     m_state.contrast = c;
     m_state.gamma = g;
+}
+
+void TagFrame::set_name(QString new_name) {
+    name = new_name;
 }
 
 void TagFrame::read(const QJsonObject &json) {

--- a/ViAn/Project/Analysis/tagframe.cpp
+++ b/ViAn/Project/Analysis/tagframe.cpp
@@ -22,31 +22,13 @@ void TagFrame::update_color_correction(int b, double c, double g) {
 
 void TagFrame::read(const QJsonObject &json) {
     VideoState state;
-    m_frame = json["frame"].toInt();
-    state.frame = m_frame;
-    state.scale_factor = json["scale_factor"].toDouble();
-    int x = json["anchor x"].toInt();
-    int y = json["anchor y"].toInt();
-    state.anchor = QPoint(x, y);
-    x = json["center_x"].toInt();
-    y = json["center_y"].toInt();
-    state.center = QPoint(x, y);
-    state.rotation = json["rotation"].toInt();
-    state.brightness = json["brightness"].toInt();
-    state.contrast = json["contrast"].toDouble();
-    state.gamma = json["gamma"].toDouble();
+    QJsonObject json_state = json["state"].toObject();
+    state.read(json_state);
     m_state = state;
 }
 
 void TagFrame::write(QJsonObject &json) {
-    json["frame"] = m_frame;
-    json["scale_factor"] = m_state.scale_factor;
-    json["anchor x"] = m_state.anchor.x();
-    json["anchor y"] = m_state.anchor.y();
-    json["center_x"] = m_state.center.x();
-    json["center_y"] = m_state.center.y();
-    json["rotation"] = m_state.rotation;
-    json["brightness"] = m_state.brightness;
-    json["contrast"] = m_state.contrast;
-    json["gamma"] = m_state.gamma;
+    QJsonObject json_state;
+    m_state.write(json_state);
+    json["state"] = json_state;
 }

--- a/ViAn/Project/Analysis/tagframe.h
+++ b/ViAn/Project/Analysis/tagframe.h
@@ -16,9 +16,11 @@ public:
     virtual void write(QJsonObject& json);
 
     void update_color_correction(int b, double c, double g);
+    void set_name(QString new_name);
 
     VideoState m_state;
     int m_frame;
+    QString name;
 };
 
 #endif // TAGFRAME_H

--- a/ViAn/Project/bookmark.cpp
+++ b/ViAn/Project/bookmark.cpp
@@ -172,18 +172,8 @@ void Bookmark::read(const QJsonObject& json){
     m_image_name = json["image name"].toString();
 
     VideoState state;
-    state.frame = json["frame"].toInt();
-    state.scale_factor = json["scale_factor"].toDouble();
-    int x = json["anchor x"].toInt();
-    int y = json["anchor y"].toInt();
-    state.anchor = QPoint(x, y);
-    x = json["center_x"].toInt();
-    y = json["center_y"].toInt();
-    state.center = QPoint(x, y);
-    state.rotation = json["rotation"].toInt();
-    state.brightness = json["brightness"].toInt();
-    state.contrast = json["contrast"].toDouble();
-    state.gamma = json["gamma"].toDouble();
+    QJsonObject json_state = json["state"].toObject();
+    state.read(json_state);
     m_state = state;
     
     m_unsaved_changes = false;
@@ -205,16 +195,9 @@ void Bookmark::write(QJsonObject& json){
     json["type"] = m_type;
     json["image name"] = m_image_name;
 
-    json["frame"] = m_state.frame;
-    json["scale_factor"] = m_state.scale_factor;
-    json["anchor x"] = m_state.anchor.x();
-    json["anchor y"] = m_state.anchor.y();
-    json["center_x"] = m_state.center.x();
-    json["center_y"] = m_state.center.y();
-    json["rotation"] = m_state.rotation;
-    json["brightness"] = m_state.brightness;
-    json["contrast"] = m_state.contrast;
-    json["gamma"] = m_state.gamma;
+    QJsonObject json_state;
+    m_state.write(json_state);
+    json["state"] = json_state;
 
     m_unsaved_changes = false;
 }

--- a/ViAn/Project/imagesequence.cpp
+++ b/ViAn/Project/imagesequence.cpp
@@ -31,7 +31,7 @@ void ImageSequence::update() {
  * @brief ImageSequence::ImageSequence
  * @param name: name of the sequence
  */
-ImageSequence::ImageSequence(const QString& path) : Video(true){
+ImageSequence::ImageSequence(const QString& path, VIDEO_TYPE seq_type) : Video(seq_type){
     m_seq_path = path;
     m_name = Utility::name_from_path(path);
 }
@@ -41,8 +41,9 @@ ImageSequence::ImageSequence(const QString& path) : Video(true){
  * @param name: name of the sequence
  * @param images: vector of paths to images
  */
-ImageSequence::ImageSequence(const QString& path, const std::vector<QString>& images, const std::vector<QString>& checksums)
-    : Video(path, true) {
+ImageSequence::ImageSequence(const QString& path, const std::vector<QString>& images,
+                             const std::vector<QString>& checksums, VIDEO_TYPE seq_type)
+    : Video(path, seq_type) {
 
     // Store image order and original file paths
     for (size_t i = 0; i < checksums.size(); ++i) {
@@ -55,10 +56,14 @@ ImageSequence::ImageSequence(const QString& path, const std::vector<QString>& im
     is_new = true;
 }
 
+std::map<QString, QString> ImageSequence::get_paths() const {
+    return m_original_images;
+}
+
 /**
  * @brief ImageSequence::get_search_path
  * Returns the absolute path to the parent folder of the images.
- * @return std::string with the actual disc path to the folder containing the images
+ * @return QString with the actual disc path to the folder containing the images
  */
 QString ImageSequence::get_search_path() const {
     return m_seq_path;
@@ -123,7 +128,7 @@ int ImageSequence::get_index_of_hash(const QString &hash) const {
  * @brief ImageSequence::get_original_name_from_hash
  * Returns the path to the original file mapped to the hash/checksum
  * @param hash
- * @return std::string containing original image path
+ * @return QString containing original image path
  */
 QString ImageSequence::get_original_name_from_hash(const QString &hash) const {
     return Utility::name_from_path(m_original_images.at(hash));

--- a/ViAn/Project/imagesequence.cpp
+++ b/ViAn/Project/imagesequence.cpp
@@ -15,6 +15,7 @@
  * This function is meant to be called before saving to file
  */
 void ImageSequence::update() {
+    qDebug() << "update";
     // If a hash from the saved order no longer exists in the unsaved order the file should be removed.
     // If this happens the file should be saved as its hash instead of index
     for (auto it = m_saved_order.begin(); it != m_saved_order.end(); ++it) {
@@ -186,12 +187,30 @@ bool ImageSequence::remove_image_with_hash(const QString &hash) {
     for (auto key_val : unsaved) {
         int i = key_val.second;
         if (i > index) {
+            qDebug() << i << index << key_val.first;
             rename_image_on_disc(Utility::zfill(i, INDEX_LENGTH), Utility::zfill(i - 1, INDEX_LENGTH));
             m_unsaved_order[key_val.first] = i - 1;
         }
     }
     m_is_saved = false;
     return true;
+}
+
+bool ImageSequence::remove_image_with_index(const int& index) {
+    QString hash = "Invalid path";
+    bool found_hash = false;
+    for (auto elem : m_unsaved_order) {
+        if (elem.second == index) {
+            hash = elem.first;
+            found_hash = true;
+            break;
+        }
+    }
+
+    if (found_hash) {
+        return remove_image_with_hash(hash);
+    }
+    return false;
 }
 
 /**
@@ -201,6 +220,7 @@ bool ImageSequence::remove_image_with_hash(const QString &hash) {
  * @return bool whether the file was removed or not
  */
 bool ImageSequence::remove_image_from_disc(const QString &image_name) const {
+    qDebug() << "remove";
     return QFile().remove(m_seq_path + "/" + image_name);
 }
 
@@ -227,7 +247,7 @@ int ImageSequence::length(){
 
 /**
  * @brief ImageSequence::restore
- * Restores the image sequnce to the last saved order by
+ * Restores the image sequence to the last saved order by
  * renaming all files on disc to the indices stored in the
  * save order map.
  * If the sequence never has been saved all files will be removed.

--- a/ViAn/Project/imagesequence.h
+++ b/ViAn/Project/imagesequence.h
@@ -48,6 +48,7 @@ public:
 
     void set_remove(const bool& remove);
     bool remove_image_with_hash(const QString& hash);
+    bool remove_image_with_index(const int& index);
     bool remove_image_from_disc(const QString& image_name) const;
     bool rename_image_on_disc(const QString& old_name, const QString& new_name) const;
     void add_image(const QString &image_path, const int& index=-1); //UNUSED TODO REMOVE?

--- a/ViAn/Project/imagesequence.h
+++ b/ViAn/Project/imagesequence.h
@@ -29,8 +29,11 @@ private:
     bool is_new{false};
 
 public:
-    ImageSequence(const QString& name);
-    ImageSequence(const QString& name, const std::vector<QString>& images, const std::vector<QString>& checksums);
+    ImageSequence(const QString& name, VIDEO_TYPE seq_type = VIDEO_SEQUENCE);
+    ImageSequence(const QString& name, const std::vector<QString>& images,
+                  const std::vector<QString>& checksums, VIDEO_TYPE seq_type = VIDEO_SEQUENCE);
+
+    std::map<QString, QString> get_paths() const;
 
     QString get_search_path() const;
     QString get_pattern_name();

--- a/ViAn/Project/project.cpp
+++ b/ViAn/Project/project.cpp
@@ -45,7 +45,6 @@ Project::~Project(){
     for (auto video_proj : m_videos) {
         delete video_proj;
     }
-
     m_videos.clear();
 }
 
@@ -79,7 +78,6 @@ void Project::remove_video_project(VideoProject* vid_proj){
     delete *it;
     m_videos.erase(it);
     m_unsaved_changes = true;
-    *it = nullptr; // Not need?
 }
 
 void Project::add_bookmark(Bookmark* bmark) {

--- a/ViAn/Project/video.cpp
+++ b/ViAn/Project/video.cpp
@@ -85,3 +85,31 @@ void Video::write(QJsonObject& json){
     json["file_path"] = this->file_path;
     m_is_saved = true;
 }
+
+void VideoState::read(const QJsonObject& json) {
+   frame = json["frame"].toInt();
+   scale_factor = json["scale_factor"].toDouble();
+   int x = json["anchor x"].toInt();
+   int y = json["anchor y"].toInt();
+   anchor = QPoint(x, y);
+   x = json["center_x"].toInt();
+   y = json["center_y"].toInt();
+   center = QPoint(x, y);
+   rotation = json["rotation"].toInt();
+   brightness = json["brightness"].toInt();
+   contrast = json["contrast"].toDouble();
+   gamma = json["gamma"].toDouble();
+}
+
+void VideoState::write(QJsonObject& json) {
+   json["frame"] = frame;
+   json["scale_factor"] = scale_factor;
+   json["anchor x"] = anchor.x();
+   json["anchor y"] = anchor.y();
+   json["center_x"] = center.x();
+   json["center_y"] = center.y();
+   json["rotation"] = rotation;
+   json["brightness"] = brightness;
+   json["contrast"] = contrast;
+   json["gamma"] = gamma;
+}

--- a/ViAn/Project/video.cpp
+++ b/ViAn/Project/video.cpp
@@ -4,8 +4,8 @@
 /**
  * @brief Video::Video
  */
-Video::Video(const bool& is_sequence){
-    m_is_sequence = is_sequence;
+Video::Video(const VIDEO_TYPE& sequence_type){
+    m_sequence_type = sequence_type;
     this->file_path = "";
 }
 
@@ -14,11 +14,11 @@ Video::Video(const bool& is_sequence){
  * @param id
  * @param filepath
  */
-Video::Video(QString file_path, const bool& is_sequence){
-    m_is_sequence = is_sequence;
+Video::Video(QString file_path, const VIDEO_TYPE &sequence_type){
+    m_sequence_type = sequence_type;
     this->file_path = file_path;
     m_name = Utility::name_from_path(file_path);
-    m_is_saved = !is_sequence; // Ordinary videos can't be changed thus are allways "saved"
+    m_is_saved = (m_sequence_type == VIDEO); // Ordinary videos can't be changed thus are allways "saved"
 }
 
 Video::~Video() {}
@@ -32,7 +32,11 @@ void Video::set_name(const QString &new_name) {
 }
 
 bool Video::is_sequence() {
-    return m_is_sequence;
+    return m_sequence_type != VIDEO;
+}
+
+VIDEO_TYPE Video::get_sequence_type() {
+    return m_sequence_type;
 }
 
 bool Video::is_saved() {
@@ -68,7 +72,7 @@ bool operator==(Video v1, Video v2){
  * Read video parameters from json object.
  */
 void Video::read(const QJsonObject& json){
-    m_is_sequence = json["sequence"].toBool();
+    m_sequence_type = static_cast<VIDEO_TYPE>(json["sequence"].toInt());
     this->file_path = json["file_path"].toString();
     m_name = json["name"].toString();
     m_is_saved = true;
@@ -80,7 +84,7 @@ void Video::read(const QJsonObject& json){
  * Write video parameters to json object.
  */
 void Video::write(QJsonObject& json){
-    json["sequence"] = m_is_sequence;
+    json["sequence"] = m_sequence_type;
     json["name"] = m_name;
     json["file_path"] = this->file_path;
     m_is_saved = true;

--- a/ViAn/Project/video.h
+++ b/ViAn/Project/video.h
@@ -10,7 +10,7 @@
 #include <QJsonObject>
 #include <QPoint>
 
-struct VideoState {
+struct VideoState : Writeable {
     int frame = 0;
     double contrast = Constants::CONTRAST_DEFAULT;
     int brightness = Constants::BRIGHTNESS_DEFAULT;
@@ -33,6 +33,8 @@ struct VideoState {
         center = rh.center;
         video = rh.video;
     }
+    virtual void read(const QJsonObject& json);
+    virtual void write(QJsonObject& json);
 };
 
 typedef int ID;

--- a/ViAn/Project/video.h
+++ b/ViAn/Project/video.h
@@ -3,7 +3,6 @@
 
 #include "constants.h"
 #include "Filehandler/saveable.h"
-//#include "Video/framemanipulator.h"
 
 #include "opencv2/core/core.hpp"
 
@@ -35,23 +34,26 @@ struct VideoState {
     }
 };
 
+enum VIDEO_TYPE {VIDEO, VIDEO_SEQUENCE, TAG_SEQUENCE};
+
 typedef int ID;
 class Video : Writeable{
 protected:
     QString m_name;
-    bool m_is_sequence;
+    VIDEO_TYPE m_sequence_type;
     bool m_is_saved{false};
     int m_width, m_height = 0;
 public:
     VideoState state;
 public:
-    Video(const bool& is_sequence=false);
-    Video(QString file_path, const bool& is_sequence=false);
+    Video(const VIDEO_TYPE &sequence_type=VIDEO);
+    Video(QString file_path, const VIDEO_TYPE &sequence_type=VIDEO);
     ~Video();
     QString file_path;
     QString get_name();
     void set_name(const QString &new_name);
     bool is_sequence();
+    VIDEO_TYPE get_sequence_type();
     bool is_saved();
     int get_width();
     int get_height();

--- a/ViAn/Project/video.h
+++ b/ViAn/Project/video.h
@@ -15,7 +15,7 @@ struct VideoState {
     int brightness = Constants::BRIGHTNESS_DEFAULT;
     double gamma = Constants::GAMMA_DEFAULT;
     int rotation = 0;
-    double scale_factor = 1;
+    double scale_factor = -1;
     QPoint anchor = QPoint(0,0);
     // Center point is relative the rotation
     QPoint center = QPoint(-1,-1);

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -108,7 +108,7 @@ void VideoProject::read(const QJsonObject& json){
     for (int j = 0; j < json_analyses.size(); ++j) {
         QJsonObject json_analysis = json_analyses[j].toObject();        
         BasicAnalysis* analysis = nullptr;
-        ANALYSIS_TYPE save_type = (ANALYSIS_TYPE)json_analysis["analysis_type"].toInt();
+        ANALYSIS_TYPE save_type = static_cast<ANALYSIS_TYPE>(json_analysis["analysis_type"].toInt());
         switch(save_type){
         case TAG:
             analysis = new Tag();

--- a/ViAn/Project/videoproject.cpp
+++ b/ViAn/Project/videoproject.cpp
@@ -108,7 +108,7 @@ void VideoProject::read(const QJsonObject& json){
     for (int j = 0; j < json_analyses.size(); ++j) {
         QJsonObject json_analysis = json_analyses[j].toObject();        
         BasicAnalysis* analysis = nullptr;
-        ANALYSIS_TYPE save_type = static_cast<ANALYSIS_TYPE>(json_analysis["analysis_type"].toInt());
+        int save_type = json_analysis["analysis_type"].toInt();
         switch(save_type){
         case TAG:
             analysis = new Tag();
@@ -121,6 +121,9 @@ void VideoProject::read(const QJsonObject& json){
             break;
         case INTERVAL:
             analysis = new Interval();
+            break;
+        case SEQUENCE_TAG:
+            analysis = new Tag("Images", SEQUENCE_TAG);
             break;
         default:
             qWarning("Something went wrong. Undefined analysis");

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -90,7 +90,8 @@ SOURCES += main.cpp \
     GUI/viewpathdialog.cpp \
     GUI/viewpathitem.cpp \
     GUI/settingsdialog.cpp \
-    constants.cpp
+    constants.cpp \
+    GUI/sequencedialog.cpp
 
 #
 # TEST
@@ -171,7 +172,8 @@ HEADERS += reportgenerator.h\
     GUI/viewpathdialog.h \
     GUI/viewpathitem.h \
     GUI/settingsdialog.h \
-    constants.h
+    constants.h \
+    GUI/sequencedialog.h
 
 #
 # LIBRARY

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -191,6 +191,7 @@ signals:
     void set_bri_cont(int, double, double);
     void done_processing(cv::Mat org_frame, cv::Mat mod_frame, int frame_index);
     void zoom_preview(cv::Mat preview_frame);
+    void new_frame_size(int width, int height);
 private:
     void process_frame();
     void update_zoomer_settings();
@@ -199,6 +200,7 @@ private:
     void update_rotation(const int& rotation);
 
     void reset_settings();
+    void update_frame_size();
     void load_zoomer_state();
     void emit_zoom_data();
 };

--- a/ViAn/Video/frameprocessor.h
+++ b/ViAn/Video/frameprocessor.h
@@ -143,6 +143,8 @@ class FrameProcessor : public QObject {
     std::atomic_bool* m_overlay_changed;
     // New video loaded by video player
     std::atomic_bool* m_new_frame_video;
+    // New frame is in loading, not yet done
+    std::atomic_bool* m_frame_changing;
 
     /**
      *  Input settings,
@@ -177,7 +179,7 @@ public:
     FrameProcessor(std::atomic_bool* new_frame, std::atomic_bool* changed,
                    zoomer_settings* z_settings, std::atomic_int* width, std::atomic_int* height,
                    std::atomic_bool* new_frame_video, manipulation_settings* m_settings, video_sync* v_sync,
-                   std::atomic_int* frame_index, overlay_settings *o_settings, std::atomic_bool *overlay_changed, std::atomic_bool *abort);
+                   std::atomic_int* frame_index, overlay_settings *o_settings, std::atomic_bool *overlay_changed, std::atomic_bool *abort, std::atomic_bool *frame_changing);
     ~FrameProcessor();
 
 public slots:

--- a/ViAn/Video/videoplayer.cpp
+++ b/ViAn/Video/videoplayer.cpp
@@ -48,7 +48,6 @@ void VideoPlayer::load_video() {
     if (m_capture.isOpened()) {
         m_capture.release();
     }
-    m_new_video->store(false);
 
     current_frame = 0;
     m_is_playing->store(false);

--- a/ViAn/Video/zoomer.cpp
+++ b/ViAn/Video/zoomer.cpp
@@ -230,14 +230,11 @@ void Zoomer::load_state(QPoint center_point, double scale_factor, int angle) {
     // Check for default state
     if (center_point.x() == -1 && center_point.y() == -1) {
         if (scale_factor == -1.) {
-            qDebug() << "Fitting";
             fit_viewport();
         } else {
-            qDebug() << "center";
             center();
         }
     } else {
-        qDebug() << "else";
         m_viewport = cv::RotatedRect(cv::Point2f(center_point.x(), center_point.y()),
                                      m_viewport.size, m_angle);
         update_anchor();
@@ -346,7 +343,6 @@ void Zoomer::reset() {
  * Centers the viewport rectangle on the frame
  */
 void Zoomer::center() {
-    qDebug() << "in center pt2";
     int center_x{m_transformed_frame_rect.tl().x + m_transformed_frame_rect.br().x / 2}, center_y{m_transformed_frame_rect.tl().y + m_transformed_frame_rect.br().y / 2};
     m_viewport = cv::RotatedRect(cv::Point2f(center_x, center_y), m_viewport.size, m_angle);
     update_anchor();

--- a/ViAn/Video/zoomer.cpp
+++ b/ViAn/Video/zoomer.cpp
@@ -229,15 +229,17 @@ void Zoomer::load_state(QPoint center_point, double scale_factor, int angle) {
 
     // Check for default state
     if (center_point.x() == -1 && center_point.y() == -1) {
-        if (scale_factor == 1.) {
+        if (scale_factor == -1.) {
+            qDebug() << "Fitting";
             fit_viewport();
         } else {
+            qDebug() << "center";
             center();
         }
     } else {
+        qDebug() << "else";
         m_viewport = cv::RotatedRect(cv::Point2f(center_point.x(), center_point.y()),
-                                     m_viewport.size,
-                                     m_angle);
+                                     m_viewport.size, m_angle);
         update_anchor();
     }
 }
@@ -344,6 +346,7 @@ void Zoomer::reset() {
  * Centers the viewport rectangle on the frame
  */
 void Zoomer::center() {
+    qDebug() << "in center pt2";
     int center_x{m_transformed_frame_rect.tl().x + m_transformed_frame_rect.br().x / 2}, center_y{m_transformed_frame_rect.tl().y + m_transformed_frame_rect.br().y / 2};
     m_viewport = cv::RotatedRect(cv::Point2f(center_x, center_y), m_viewport.size, m_angle);
     update_anchor();

--- a/ViAn/Video/zoomer.h
+++ b/ViAn/Video/zoomer.h
@@ -40,7 +40,7 @@ public:
     void point_zoom(QPoint, double zoom_step);
     void update_rotation(const int& angle);
     void translate_viewport_center(int x, int y);
-    void load_state(QPoint anchor, double scale_factor, int angle);
+    void load_state(QPoint center, double scale_factor, int angle);
     void fit_viewport();
     void scale_frame(cv::Mat& frame);
     void reset();

--- a/ViAn/imageimporter.cpp
+++ b/ViAn/imageimporter.cpp
@@ -7,10 +7,12 @@
 #include <QDir>
 #include <QFileInfo>
 
-ImageImporter::ImageImporter(const QStringList& images, const QString& dest, QObject *parent) :
+ImageImporter::ImageImporter(const QStringList& images, const QString& dest,
+                             const int &sequence_type, QObject *parent) :
+    QObject(parent),
     m_images(images),
     m_dest(Utility::add_serial_number(dest, "")),
-    QObject(parent) {}
+    m_type(sequence_type) {}
 
 /**
  * @brief ImageImporter::import_images
@@ -70,7 +72,7 @@ void ImageImporter::import_images() {
         m_abort = true;
     }
 
-    if (!m_abort) {emit imported_sequence(m_images, checksums, m_dest);}
+    if (!m_abort) {emit imported_sequence(m_images, checksums, m_dest, m_type);}
     emit update_progress(m_images.size());
     emit finished();
 }

--- a/ViAn/imageimporter.h
+++ b/ViAn/imageimporter.h
@@ -8,16 +8,18 @@ class ImageImporter : public QObject
     Q_OBJECT
     QStringList m_images{};
     QString m_dest{};
+    int m_type;
     bool m_abort{false};
 public:
-    explicit ImageImporter(const QStringList& images, const QString& dest, QObject *parent = nullptr);
+    explicit ImageImporter(const QStringList& images, const QString& dest,
+                           const int &sequence_type, QObject *parent = nullptr);
 
 public slots:
     void import_images();
     void abort();
 signals:
     void finished();
-    void imported_sequence(QStringList images, QStringList checksums, QString path);
+    void imported_sequence(QStringList images, QStringList checksums, QString path, int seq_path);
     void update_progress(int progress);
 };
 

--- a/ViAn/reportgenerator.h
+++ b/ViAn/reportgenerator.h
@@ -8,9 +8,6 @@ class QAxObject;
 class QListWidgetItem;
 
 enum TABLE_STYLE {NO_BORDER = 0, BORDER=36};
-using RefDisp = std::pair<std::vector<BookmarkItem*>,std::vector<BookmarkItem*>>;
-using Category = std::pair<QString,RefDisp>;
-using ReportContainer = std::vector<Category>;
 
 /**
  * @brief The ReportGenerator class


### PR DESCRIPTION
The new solution for the tag sequences. Saves them as normal tags. And saves the state in the tag.

Not completely done yet but putting it up here so it can be tested.
Known problems right now: 
 - The first image clicked after loading will decide the zoom lvl. Something with fit viewport have to be looked at.
 - There seems to be a crash when closing the project.

------------

And yes i merged the bookmark order branch. Since i wanted the latest code in case that branch fixes some issues.


----------------------------
Newset edit:
It's mostly done, at least from the user's side.
The sync problem should be fixed or at least be a lot better with the new "frame_changing" variable from the videowidget. This variable tells the processor that there will come a new frame so it doesn't update the old frame with the new frame's state.
I sped through the changed towards the end, because I wanted to be as finished as possible before the holidays. This means that the deletions of single frames and of the whole tag on a tag sequence is not done correctly. But it should work from the users side (not crash). It might leaves some memory left uncleaned and some files left in the folder (in the case of the deleting a single frame).