### PR TITLE
Minimized the sync problem

### DIFF
--- a/ViAn/GUI/DrawingItems/frameitem.cpp
+++ b/ViAn/GUI/DrawingItems/frameitem.cpp
@@ -18,3 +18,8 @@ Shapes* FrameItem::get_shape() {
 int FrameItem::get_frame() {
     return m_frame;
 }
+
+void FrameItem::set_frame(int frame) {
+    m_frame = frame;
+    setText(0, QString::number(frame));
+}

--- a/ViAn/GUI/DrawingItems/frameitem.h
+++ b/ViAn/GUI/DrawingItems/frameitem.h
@@ -9,6 +9,7 @@ public:
     FrameItem(int frame);
 
     int get_frame();
+    void set_frame(int frame);
     void remove() override;
     Shapes* get_shape() override;
     ~FrameItem() override;

--- a/ViAn/GUI/TreeItems/tagframeitem.cpp
+++ b/ViAn/GUI/TreeItems/tagframeitem.cpp
@@ -11,7 +11,9 @@ TagFrameItem::TagFrameItem(TagFrame* t_frame) : TreeItem(TAG_FRAME_ITEM) {
 }
 
 VideoState TagFrameItem::get_state() {
-    return *(m_t_frame->m_state);
+    VideoState state;
+    state = m_t_frame->get_state();
+    return state;
 }
 
 void TagFrameItem::remove(){}
@@ -21,5 +23,5 @@ void TagFrameItem::rename() {
 }
 
 int TagFrameItem::get_frame() {
-    return m_t_frame->m_state->frame;
+    return m_t_frame->get_state().frame;
 }

--- a/ViAn/GUI/TreeItems/videoitem.cpp
+++ b/ViAn/GUI/TreeItems/videoitem.cpp
@@ -8,6 +8,7 @@
 #include "sequenceitem.h"
 
 #include "opencv2/core/core.hpp"
+#include "opencv2/imgproc/imgproc.hpp"
 #include "opencv2/videoio/videoio.hpp"
 
 #include <QTreeWidgetItem>
@@ -59,6 +60,14 @@ void VideoItem::set_thumbnail() {
     }
     cv::Mat frame;
     cap >> frame;
+    switch (frame.type()) {
+        case CV_8UC1:
+            cvtColor(frame, frame, CV_GRAY2RGB);
+            break;
+        case CV_8UC3:
+            cvtColor(frame, frame, CV_BGR2RGB);
+            break;
+    }
     ImageGenerator im_gen(frame, m_vid_proj->get_proj_path());
     QString thumbnail_path = im_gen.create_thumbnail(m_vid_proj->get_video()->get_name());
     const QIcon icon(thumbnail_path);

--- a/ViAn/GUI/drawingwidget.cpp
+++ b/ViAn/GUI/drawingwidget.cpp
@@ -287,22 +287,23 @@ void DrawingWidget::tree_item_clicked(QTreeWidgetItem *item, const int &col) {
     if (!item) return;
     switch (item->type()) {
     case FRAME_ITEM: {
+        emit set_current_drawing(nullptr);
         FrameItem* frame_item = dynamic_cast<FrameItem*>(item);
-
         VideoState state;
         state = m_vid_proj->get_video()->state;
         state.frame = frame_item->get_frame();
-
+        // Reset these to default values so the zoomer will fit to viewport
+        state.center = QPoint(-1, -1);
+        state.scale_factor = -1;
         emit jump_to_frame(m_vid_proj, state);
-        emit set_current_drawing(nullptr);
         break;
     }
     case RECT_ITEM:
     case CIRCLE_ITEM:
-    case LINE_ITEM:
     case ARROW_ITEM:
-    case TEXT_ITEM:
-    case PEN_ITEM: {
+    case LINE_ITEM:
+    case PEN_ITEM:
+    case TEXT_ITEM: {
         ShapeItem* shape_item = dynamic_cast<ShapeItem*>(item);
         Shapes* shape = shape_item->get_shape();
         if (col == 1) {
@@ -314,14 +315,15 @@ void DrawingWidget::tree_item_clicked(QTreeWidgetItem *item, const int &col) {
         } else if (col == 2) {
             shape_item->update_show_icon(shape->toggle_show());
         }
-
+        emit set_tool_edit();
+        emit set_current_drawing(shape);
         VideoState state;
         state = m_vid_proj->get_video()->state;
         state.frame = shape->get_frame();
-
+        // Reset these to default values so the zoomer will fit to viewport
+        state.center = QPoint(-1, -1);
+        state.scale_factor = -1;
         emit jump_to_frame(m_vid_proj, state);
-        emit set_current_drawing(shape);
-        emit set_tool_edit();
         break;
     }
     default:

--- a/ViAn/GUI/drawingwidget.cpp
+++ b/ViAn/GUI/drawingwidget.cpp
@@ -393,6 +393,42 @@ void DrawingWidget::remove_item() {
     remove_from_tree(currentItem());
 }
 
+/**
+ * @brief DrawingWidget::remove_item_frame
+ * Called when a frame is removed from a sequence.
+ * Updates the drawings and widget with the new frame numbers
+ * @param frame
+ */
+void DrawingWidget::remove_item_frame(int frame) {
+    blockSignals(true);
+    auto root = invisibleRootItem();
+    bool found = false;
+    QTreeWidgetItem* item = nullptr;
+    for (int i = 0; i < root->childCount(); i++) {
+        QTreeWidgetItem* t_item = root->child(i);
+        if (found) {
+            // Lowering frame by one
+            FrameItem* f_item = dynamic_cast<FrameItem*>(t_item);
+            f_item->set_frame(f_item->get_frame()-1);
+            // Update all shapes with the new frame
+            for (int j = 0; j < t_item->childCount(); j++) {
+                ShapeItem* s_item = dynamic_cast<ShapeItem*>(t_item->child(j));
+                Shapes* shape = s_item->get_shape();
+                shape->set_frame(shape->get_frame()-1);
+            }
+        }
+        if (t_item->text(0) == QString::number(frame) && !found) {
+            item = t_item;
+            found = true;
+        }
+    }
+    if (found) {
+        remove_from_tree(item);
+    }
+    m_overlay->remove_frame(frame);
+    blockSignals(false);
+}
+
 void DrawingWidget::delete_item() {
     if (!currentItem() || m_overlay->get_tool() != EDIT) return;
     ShapeItem* item = dynamic_cast<ShapeItem*>(currentItem());

--- a/ViAn/GUI/drawingwidget.h
+++ b/ViAn/GUI/drawingwidget.h
@@ -35,6 +35,7 @@ public slots:
     void context_menu(const QPoint& point);
     void rename_item();
     void remove_item();
+    void remove_item_frame(int frame);
     void delete_item();
     void item_changed(QTreeWidgetItem*);
 

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -103,6 +103,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
     connect(project_wgt, &ProjectWidget::save_draw_wgt, drawing_wgt, &DrawingWidget::save_item_data);
     connect(video_wgt, &VideoWidget::delete_sc_activated, drawing_wgt, &DrawingWidget::delete_item);
+    connect(project_wgt, &ProjectWidget::remove_frame, drawing_wgt, &DrawingWidget::remove_item_frame);
 
     // Initialize bookmark widget
     bookmark_wgt = new BookmarkWidget();

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -457,8 +457,7 @@ void ProjectWidget::tree_add_video(VideoProject* vid_proj, const QString& vid_na
                 // Create the tagframe
                 VideoState state;
                 state.frame = frame;
-                VideoState* state_p = new VideoState(state);
-                TagFrame* t_frame = new TagFrame(frame, state_p);
+                TagFrame* t_frame = new TagFrame(frame, state);
                 t_frame->set_name(Utility::name_from_path(path));
                 tag->add_frame(frame, t_frame);
             }
@@ -1205,8 +1204,7 @@ void ProjectWidget::drawing_tag() {
         if (frame_overlay.second.size() > 0) {
             VideoState state;
             state.frame = frame_overlay.first;
-            VideoState* state_p = new VideoState(state);
-            TagFrame* t_frame = new TagFrame(frame_overlay.first, state_p);
+            TagFrame* t_frame = new TagFrame(frame_overlay.first, state);
             tag->add_frame(frame_overlay.first, t_frame);
         }
     }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -812,10 +812,11 @@ void ProjectWidget::tree_item_changed(QTreeWidgetItem* item, QTreeWidgetItem* pr
         VideoItem* vid_item = dynamic_cast<VideoItem*>(item);
         if (vid_item->get_video_project() == nullptr) return;
         emit set_video_project(vid_item->get_video_project());
-        VideoState state;
-        vid_item->get_video_project()->state.video = true;
-        state = vid_item->get_video_project()->state;
-        emit marked_video_state(vid_item->get_video_project(), state);
+        if (!vid_item->get_video_project()->get_video()->is_sequence()) {
+            VideoState state;
+            state = vid_item->get_video_project()->state;
+            emit marked_video_state(vid_item->get_video_project(), state);
+        }
         emit item_type(item->type());
 
         emit set_zoom_tool();

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1413,6 +1413,10 @@ void ProjectWidget::remove_tag_frame_item(QTreeWidgetItem *item) {
             tag->remove_frame(frame);
             tag->update_index_tag();
             emit new_slider_max(-1);
+
+            // Update drawing widget
+            emit remove_frame(frame);
+
             tree_item_changed(item->parent()->parent());
         }
     } else {

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1197,7 +1197,7 @@ void ProjectWidget::drawing_tag() {
         return;
     }
     // Create tag drawing
-    Tag* tag = new Tag("Drawing tag", true);
+    Tag* tag = new Tag("Drawing tag", DRAWING_TAG);
 
     // Add all drawings to tag frame items.
     VideoProject* vid_proj = vid_item->get_video_project();

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1427,6 +1427,7 @@ void ProjectWidget::remove_tag_frame_item(QTreeWidgetItem *item) {
 void ProjectWidget::remove_sequence_item(QTreeWidgetItem *item) {
     SequenceItem* seq_item = dynamic_cast<SequenceItem*>(item);
     if (seq_item) {
+        emit remove_frame(seq_item->get_index());
         seq_item->remove();
     }
 }

--- a/ViAn/GUI/projectwidget.cpp
+++ b/ViAn/GUI/projectwidget.cpp
@@ -1140,15 +1140,16 @@ void ProjectWidget::context_menu(const QPoint &point) {
             menu.addAction("Delete", this, &ProjectWidget::remove_item);
             break;
         case TAG_FRAME_ITEM: {
-            TagItem* t_item = dynamic_cast<TagItem*>(item->parent());
-            Tag* tag = t_item->get_tag();
-            if (tag->get_type() == SEQUENCE_TAG) {
+            if (item->parent()->type() == TAG_ITEM) {
+                TagItem* t_item = dynamic_cast<TagItem*>(item->parent());
+                Tag* tag = t_item->get_tag();
+                if (tag->get_type() == TAG) {
+                    menu.addAction("Update", this, &ProjectWidget::update_tag);
+                }
                 menu.addAction("Delete", this, &ProjectWidget::remove_item);
                 break;
-            }
-            menu.addAction("Update", this, &ProjectWidget::update_tag);
-            if (item->parent()->type() == TAG_ITEM) {
-                menu.addAction("Delete", this, &ProjectWidget::remove_item);
+            } else if (item->parent()->type() == DRAWING_TAG_ITEM) {
+                menu.addAction("Update", this, &ProjectWidget::update_tag);
             }
             break;
         }

--- a/ViAn/GUI/projectwidget.h
+++ b/ViAn/GUI/projectwidget.h
@@ -78,6 +78,7 @@ signals:
     void item_type(int);
     void update_tag();
     void new_slider_max(int);
+    void remove_frame(int);
 
 public slots:
     void new_project(void);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -666,7 +666,7 @@ void VideoWidget::set_zoom_state(QPoint center, double scale, int angle) {
         }
         if (m_tag && m_vid_proj->get_video()->get_sequence_type() == TAG_SEQUENCE) {
             TagFrame* t_frame = m_tag->tag_map.at(frame_index.load());
-            t_frame->get_original().center = center;
+            t_frame->set_center(center);
             t_frame->set_scale_rot(scale, angle);
         }
         Video* video = m_vid_proj->get_video();

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -829,6 +829,7 @@ void VideoWidget::update_tag_color(int b, double c, double g) {
  * Adds the current frame to a tag.
  */
 void VideoWidget::tag_frame() {
+    if (!tag_btn->isEnabled()) return;
     // If no tag is selected show the new tag dialog
     if (m_tag == nullptr || m_tag->is_drawing_tag()) {
         new_tag_clicked();
@@ -879,6 +880,7 @@ void VideoWidget::remove_tag_frame() {
  * New-tag button clicked
  */
 void VideoWidget::new_tag_clicked() {
+    if (!tag_btn->isEnabled()) return;
     if (!m_vid_proj || frame_is_clean) return;
     TagDialog* tag_dialog = new TagDialog();
     tag_dialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -666,9 +666,8 @@ void VideoWidget::set_zoom_state(QPoint center, double scale, int angle) {
         }
         if (m_tag && m_vid_proj->get_video()->get_sequence_type() == TAG_SEQUENCE) {
             TagFrame* t_frame = m_tag->tag_map.at(frame_index.load());
-            t_frame->m_state->center = center;
-            t_frame->m_state->scale_factor = scale;
-            t_frame->m_state->rotation = angle;
+            t_frame->get_original().center = center;
+            t_frame->set_scale_rot(scale, angle);
         }
         Video* video = m_vid_proj->get_video();
         video->state.center = center;
@@ -805,10 +804,9 @@ void VideoWidget::update_tag() {
     try {
         TagFrame* t_frame = m_tag->tag_map.at(playback_slider->value());
         VideoState state = m_vid_proj->get_video()->state;
-        t_frame->m_state = &state;
-        t_frame->m_state->brightness = m_settings.brightness;
-        t_frame->m_state->contrast = m_settings.contrast;
-        t_frame->m_state->gamma = m_settings.gamma;
+        t_frame->get_original() = state;
+        t_frame->update_color_correction(m_settings.brightness, m_settings.contrast,
+                                         m_settings.gamma);
         emit set_status_bar("Frame number: " + QString::number(playback_slider->value()) + " updated");
     } catch (const std::out_of_range) {
         qWarning() << "Can't update. No tag found on current frame";
@@ -848,7 +846,7 @@ void VideoWidget::tag_frame() {
         } else {
             // Add frame to tag
             VideoState state = m_vid_proj->get_video()->state;
-            TagFrame* t_frame = new TagFrame(playback_slider->value(), &state);
+            TagFrame* t_frame = new TagFrame(playback_slider->value(), state);
             m_tag->add_frame(playback_slider->value(), t_frame);
             emit tag_new_frame(playback_slider->value(), t_frame);
             emit set_status_bar("Frame number: " + QString::number(playback_slider->value()) + " tagged");
@@ -935,7 +933,7 @@ void VideoWidget::next_poi_btn_clicked() {
     if (new_frame != current_frame) {
         if (playback_slider->get_show_tags()) {
             VideoState state;
-            state = *(playback_slider->m_tag->tag_map[new_frame]->m_state);
+            state = playback_slider->m_tag->tag_map[new_frame]->get_state();
             load_marked_video_state(m_vid_proj, state);
         }
         {
@@ -959,7 +957,7 @@ void VideoWidget::prev_poi_btn_clicked() {
     if (new_frame != current_frame) {
         if (playback_slider->get_show_tags()) {
             VideoState state;
-            state = *(playback_slider->m_tag->tag_map[new_frame]->m_state);
+            state = playback_slider->m_tag->tag_map[new_frame]->get_state();
             load_marked_video_state(m_vid_proj, state);
         }
         {
@@ -1085,7 +1083,7 @@ void VideoWidget::on_playback_slider_moved() {
  * @param vid_proj
  */
 void VideoWidget::load_marked_video_state(VideoProject* vid_proj, VideoState state) {
-
+    set_seq_tag_btns(false);
     if (!video_btns_enabled) set_video_btns(true);
     if (!vid_proj->is_current() || m_vid_proj == nullptr) {
         if (m_vid_proj) m_vid_proj->set_current(false);

--- a/ViAn/GUI/videowidget.cpp
+++ b/ViAn/GUI/videowidget.cpp
@@ -1015,7 +1015,7 @@ void VideoWidget::on_new_frame() {
     frame_line_edit->setText(QString::number(frame_num));
 
     if (!m_floating) {
-        if (proj_tree_item == VIDEO_ITEM) {
+        if (proj_tree_item == VIDEO_ITEM || proj_tree_item == ANALYSIS_ITEM) {
             m_vid_proj->state.frame = frame_num;
         }
         m_vid_proj->get_video()->state.frame = frame_num;

--- a/ViAn/Project/Analysis/tag.cpp
+++ b/ViAn/Project/Analysis/tag.cpp
@@ -60,9 +60,7 @@ void Tag::update_color_correction(int frame, int b_value, double c_value, double
  */
 void Tag::update_color_whole_tag(int b, double c, double g) {
     for (auto it = tag_map.begin(); it != tag_map.end(); ++it) {
-        (*it).second->m_state->brightness = b;
-        (*it).second->m_state->contrast = c;
-        (*it).second->m_state->gamma = g;
+        (*it).second->update_color_correction(b, c, g);
     }
 }
 
@@ -77,7 +75,7 @@ void Tag::update_index_tag() {
     int index = 0;
     for (auto it = tag_map.begin(); it != tag_map.end(); ++it) {
         if (it->first != index) {
-            it->second->m_state->frame = index;
+            it->second->set_frame(index);
             temp_map[index] = it->second;
         } else {
             temp_map[index] = it->second;

--- a/ViAn/Project/Analysis/tagframe.cpp
+++ b/ViAn/Project/Analysis/tagframe.cpp
@@ -34,6 +34,10 @@ void TagFrame::set_scale_rot(double scale, int rot) {
     m_state.rotation = rot;
 }
 
+void TagFrame::set_center(QPoint center) {
+    m_state.center = center;
+}
+
 /**
  * @brief TagFrame::get_state
  * Make a copy and return

--- a/ViAn/Project/Analysis/tagframe.cpp
+++ b/ViAn/Project/Analysis/tagframe.cpp
@@ -6,39 +6,62 @@ TagFrame::TagFrame(int frame) {
     name = QString::number(frame);
 }
 
-TagFrame::TagFrame(int frame, VideoState* state) {
+TagFrame::TagFrame(int frame, VideoState state) {
     m_frame = frame;
     m_state = state;
     name = QString::number(frame);
 }
 
 TagFrame::~TagFrame() {
-    delete m_state;
 }
 
 void TagFrame::update_color_correction(int b, double c, double g) {
-    m_state->brightness = b;
-    m_state->contrast = c;
-    m_state->gamma = g;
+    m_state.brightness = b;
+    m_state.contrast = c;
+    m_state.gamma = g;
 }
 
 void TagFrame::set_name(QString new_name) {
     name = new_name;
 }
 
+void TagFrame::set_frame(int frame) {
+    m_state.frame = frame;
+}
+
+void TagFrame::set_scale_rot(double scale, int rot) {
+    m_state.scale_factor = scale;
+    m_state.rotation = rot;
+}
+
+/**
+ * @brief TagFrame::get_state
+ * Make a copy and return
+ * To prevent any update to the state.
+ * @return
+ */
+VideoState TagFrame::get_state() {
+    VideoState state;
+    state = VideoState(m_state);
+    return state;
+}
+
+VideoState TagFrame::get_original() {
+    return m_state;
+}
+
 void TagFrame::read(const QJsonObject &json) {
-    //VideoState state;
-    VideoState* state = new VideoState;
+    VideoState state;
     QJsonObject json_state = json["state"].toObject();
-    state->read(json_state);
+    state.read(json_state);
     m_state = state;
     name = json["name"].toString();
 }
 
 void TagFrame::write(QJsonObject &json) {
     QJsonObject json_state;
-    m_state->write(json_state);
+    m_state.write(json_state);
     json["state"] = json_state;
-    json["frame"] = m_state->frame;
+    json["frame"] = m_state.frame;
     json["name"] = name;
 }

--- a/ViAn/Project/Analysis/tagframe.h
+++ b/ViAn/Project/Analysis/tagframe.h
@@ -20,6 +20,7 @@ public:
     void set_name(QString new_name);
     void set_frame(int frame);
     void set_scale_rot(double scale, int rot);
+    void set_center(QPoint center);
     VideoState get_state();
     VideoState get_original();
 

--- a/ViAn/Project/Analysis/tagframe.h
+++ b/ViAn/Project/Analysis/tagframe.h
@@ -7,18 +7,22 @@
 #include <QJsonObject>
 
 class TagFrame : public Writeable {
+    VideoState m_state;
 
 public:
     TagFrame(int frame);
-    TagFrame(int frame, VideoState *state);
+    TagFrame(int frame, VideoState state);
     virtual ~TagFrame();
     virtual void read(const QJsonObject& json);
     virtual void write(QJsonObject& json);
 
     void update_color_correction(int b, double c, double g);
     void set_name(QString new_name);
+    void set_frame(int frame);
+    void set_scale_rot(double scale, int rot);
+    VideoState get_state();
+    VideoState get_original();
 
-    VideoState* m_state;
     int m_frame;
     QString name;
 };

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -528,6 +528,28 @@ void Overlay::delete_drawing(Shapes* shape) {
 }
 
 /**
+ * @brief Overlay::remove_frame
+ * Used when a frame is removed from a sequence.
+ * Updates the overlays map with the new frame numbers
+ * @param frame
+ */
+void Overlay::remove_frame(int frame) {
+    std::map<int, std::vector<Shapes*>> new_overlays;
+    bool found = false;
+    for (auto node : overlays) {
+        if (node.first == frame && !found) {
+            found = true;
+            node.second.clear();
+        } else if (found && node.first > frame) {
+            new_overlays[node.first-1] = node.second;
+        } else {
+            new_overlays[node.first] = node.second;
+        }
+    }
+    set_overlays(new_overlays);
+}
+
+/**
  * @brief Overlay::read
  * @param json
  * Reads the overlay from a Json object.

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -43,6 +43,7 @@ public:
     void update_text(QString, Shapes*shape);
     void clear(int frame_nr);
     void delete_drawing(Shapes *shape);
+    void remove_frame(int frame);
     void clear_overlay();
 
     void read(const QJsonObject& json);

--- a/ViAn/Video/zoomer.cpp
+++ b/ViAn/Video/zoomer.cpp
@@ -228,7 +228,7 @@ void Zoomer::load_state(QPoint center_point, double scale_factor, int angle) {
     adjust_frame_rect_rotation();
 
     // Check for default state
-    if (center_point.x() == -1 && center_point.y() == -1) {
+    if (center_point == QPoint(-1, -1)) {
         if (scale_factor == -1.) {
             fit_viewport();
         } else {


### PR DESCRIPTION
Moved some signals around to minimize the sync problems. Also, clicking a drawing from the drawing widget now sets the frame to fit screen.

Remove the state as a pointer as it made some problems to the normal tags and when the state was sent around. The state a tagframe was holding was updated as it was sent around. What exactly was sent wasn't certain in all places.
Removed the pointers and the tags seems to work again and the tag sequence deletion that the pointers were supposed to fix also seems to work now. This might need some more through testing with all tags variations and deletions as this was fixed quickly just before the clock became too much.