### PR TITLE
Remove the console on startup

### DIFF
--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -8,6 +8,8 @@ QT       += core gui
 QT       += testlib
 QT       += axcontainer
 
+QT.testlib.CONFIG -= console
+
 CONFIG += c++11
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets


### PR DESCRIPTION
changed the application subsystem from console to window in the linker command to remove it.

fixes #227 